### PR TITLE
fix: fixing issue where whole app crashes when card gets dissconnected during setup.

### DIFF
--- a/src/wifit3/device/manager.py
+++ b/src/wifit3/device/manager.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, List, NoReturn, Optional, Tuple
 import libusb_package
 import usb.core
 
-from wifit3.errors import BringUpError, BringUpPermissionsError, WifiteFatalError
+from wifit3.errors import BringUpError, BringUpPermissionsError, WifiteFatalError, is_device_gone
 from wifit3.models.device_id import DeviceID
 from wifit3.setup.base import Setup, SetupResult
 from wifit3.wlan.array import WlanArray
@@ -304,6 +304,8 @@ class DeviceManager:
             # else fixable: fall through to setup
         except BringUpError as e:
             return BringupResult.failed(self._fault_message(device_id, e))
+        except (usb.core.USBError, OSError) as e:
+            return BringupResult.failed(self._usb_fault_message(device_id, e))
 
         device_id = await self.setup.install(device_id, self.prompter)
         if device_id is None:
@@ -314,6 +316,8 @@ class DeviceManager:
             return BringupResult.ready()
         except BringUpError as e:
             return BringupResult.failed(self._fault_message(device_id, e))
+        except (usb.core.USBError, OSError) as e:
+            return BringupResult.failed(self._usb_fault_message(device_id, e))
 
     async def uninstall(self, device_id) -> SetupResult:
         """Reverse a prior setup for ``device_id`` (the splash's ✕ button). Shows the progress modal
@@ -358,3 +362,10 @@ class DeviceManager:
     def _fault_message(device_id, e: BringUpError) -> str:
         chip = device_id.chipset
         return f"{chip}: {e.stage} failed" + (f": {e.detail}" if e.detail else "")
+
+    @staticmethod
+    def _usb_fault_message(device_id, e: usb.core.USBError | OSError) -> str:
+        chip = device_id.chipset
+        if is_device_gone(e) or getattr(e, "errno", None) in (5, 19):
+            return f"{chip}: adapter disconnected during bring-up; replug it and try again"
+        return f"{chip}: USB I/O failed during bring-up: {e}"

--- a/src/wifit3/device/manager.py
+++ b/src/wifit3/device/manager.py
@@ -7,6 +7,7 @@ only on a match (``driver_for`` / bring-up).
 """
 from __future__ import annotations
 
+import errno
 import functools
 import importlib
 import logging
@@ -304,7 +305,7 @@ class DeviceManager:
             # else fixable: fall through to setup
         except BringUpError as e:
             return BringupResult.failed(self._fault_message(device_id, e))
-        except (usb.core.USBError, OSError) as e:
+        except OSError as e:
             return BringupResult.failed(self._usb_fault_message(device_id, e))
 
         device_id = await self.setup.install(device_id, self.prompter)
@@ -316,7 +317,7 @@ class DeviceManager:
             return BringupResult.ready()
         except BringUpError as e:
             return BringupResult.failed(self._fault_message(device_id, e))
-        except (usb.core.USBError, OSError) as e:
+        except OSError as e:
             return BringupResult.failed(self._usb_fault_message(device_id, e))
 
     async def uninstall(self, device_id) -> SetupResult:
@@ -364,8 +365,8 @@ class DeviceManager:
         return f"{chip}: {e.stage} failed" + (f": {e.detail}" if e.detail else "")
 
     @staticmethod
-    def _usb_fault_message(device_id, e: usb.core.USBError | OSError) -> str:
+    def _usb_fault_message(device_id, e: OSError) -> str:
         chip = device_id.chipset
-        if is_device_gone(e) or getattr(e, "errno", None) in (5, 19):
+        if is_device_gone(e) or e.errno in (errno.EIO, errno.ENODEV):
             return f"{chip}: adapter disconnected during bring-up; replug it and try again"
         return f"{chip}: USB I/O failed during bring-up: {e}"

--- a/tests/ui/test_bringup_error.py
+++ b/tests/ui/test_bringup_error.py
@@ -18,6 +18,7 @@ import wifit3.device.manager as manager
 from wifit3.chips.driver import DeviceID
 from wifit3.chips.rt2800usb.driver import RT2800USBDriver
 from wifit3.chips.rtl8187.driver import RTL8187Driver
+from wifit3.device.manager import DeviceManager, Status
 from wifit3.errors import BringUpError
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.screens.splash import SplashView
@@ -46,6 +47,59 @@ async def test_rt2800usb_init_io_failure_becomes_bringuperror(monkeypatch):
 
     with pytest.raises(BringUpError):
         await driver.connect()
+
+
+class _NoSetup:
+    def requires_setup(self, device_id):
+        return False
+
+    async def install(self, device_id, ui):
+        return device_id
+
+    async def uninstall(self, device_id, ui):
+        raise AssertionError("not used")
+
+
+class _Prompter:
+    async def open(self, title):
+        pass
+
+    def close(self):
+        pass
+
+    def status_progress(self, fraction, message):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_bringup_becomes_failed_result(monkeypatch):
+    err = usb.core.USBError("No such device", errno=19)
+    err.backend_error_code = -4
+    iface = SimpleNamespace(name="wlan0", connect=AsyncMock(side_effect=err), close=AsyncMock())
+    monkeypatch.setattr(manager, "wlan_iface", lambda device_id, name="wlan0": iface)
+
+    dm = DeviceManager(SimpleNamespace(array=None, notify_device_lost=lambda *a: None),
+                       setup=_NoSetup(), prompter=_Prompter())
+    res = await dm.bringup(DeviceID(0x0BDA, 0x8187, "RTL8187L", product_name="test"))
+
+    assert res.status is Status.FAILED
+    assert "disconnected during bring-up" in res.message
+    iface.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_io_error_during_bringup_becomes_failed_result(monkeypatch):
+    err = OSError(5, "Input/output error")
+    iface = SimpleNamespace(name="wlan0", connect=AsyncMock(side_effect=err), close=AsyncMock())
+    monkeypatch.setattr(manager, "wlan_iface", lambda device_id, name="wlan0": iface)
+
+    dm = DeviceManager(SimpleNamespace(array=None, notify_device_lost=lambda *a: None),
+                       setup=_NoSetup(), prompter=_Prompter())
+    res = await dm.bringup(DeviceID(0x0BDA, 0x8187, "RTL8187L", product_name="test"))
+
+    assert res.status is Status.FAILED
+    assert "disconnected during bring-up" in res.message
+    iface.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
 Now it gracefuly says the error and if its single card, continues with setup of others, DeviceWatcher was off during the initial setup and that caused the app to crash, this should be resolved now.