### PR TITLE
ui(deauth): Deauth button behaviour switched back to old

### DIFF
--- a/src/wifit3/campaigns/deauth.py
+++ b/src/wifit3/campaigns/deauth.py
@@ -29,8 +29,8 @@ class DeauthCampaign(Campaign):
 
     button_id = "btn-deauth"
     key = "deauth"
-    hotkey = ("d", "Deauth")
-    idle_label = "Deauth"
+    hotkey = ("D", "Auto Deauth")
+    idle_label = "Auto Deauth"
     run_label = "Stop Deauth"
     idle_variant = "primary"
     run_variant = "error"

--- a/src/wifit3/campaigns/deauth.py
+++ b/src/wifit3/campaigns/deauth.py
@@ -29,8 +29,8 @@ class DeauthCampaign(Campaign):
 
     button_id = "btn-deauth"
     key = "deauth"
-    hotkey = ("D", "Auto Deauth")
-    idle_label = "Auto Deauth"
+    hotkey = ("D", "AutoDeauth")
+    idle_label = "AutoDeauth"
     run_label = "Stop Deauth"
     idle_variant = "primary"
     run_variant = "error"

--- a/src/wifit3/ui/focus_model.py
+++ b/src/wifit3/ui/focus_model.py
@@ -19,8 +19,6 @@ from ..campaigns.deauth import DeauthCampaign
 from ..campaigns.eviltwin import EvilTwinCampaign
 
 # Attack-button campaigns in button-row order.
-#BUTTON_CAMPAIGNS = [WepCampaign, PmkidHarvestAttack, DeauthCampaign, WpsCampaign, EvilTwinCampaign]
-#_BUTTON_ORDER = ["btn-gen-ivs", "btn-chop", "btn-pmkid", "btn-deauth", "btn-wps-pin", "btn-eviltwin"] # kept for future, delete if okay with swapped buttons
 BUTTON_CAMPAIGNS = [WepCampaign, DeauthCampaign, PmkidHarvestAttack, WpsCampaign, EvilTwinCampaign]
 _BUTTON_ORDER = ["btn-gen-ivs", "btn-chop", "btn-deauth", "btn-pmkid", "btn-wps-pin", "btn-eviltwin"]
 

--- a/src/wifit3/ui/focus_model.py
+++ b/src/wifit3/ui/focus_model.py
@@ -19,8 +19,10 @@ from ..campaigns.deauth import DeauthCampaign
 from ..campaigns.eviltwin import EvilTwinCampaign
 
 # Attack-button campaigns in button-row order.
-BUTTON_CAMPAIGNS = [WepCampaign, PmkidHarvestAttack, DeauthCampaign, WpsCampaign, EvilTwinCampaign]
-_BUTTON_ORDER = ["btn-gen-ivs", "btn-chop", "btn-pmkid", "btn-deauth", "btn-wps-pin", "btn-eviltwin"]
+#BUTTON_CAMPAIGNS = [WepCampaign, PmkidHarvestAttack, DeauthCampaign, WpsCampaign, EvilTwinCampaign]
+#_BUTTON_ORDER = ["btn-gen-ivs", "btn-chop", "btn-pmkid", "btn-deauth", "btn-wps-pin", "btn-eviltwin"] # kept for future, delete if okay with swapped buttons
+BUTTON_CAMPAIGNS = [WepCampaign, DeauthCampaign, PmkidHarvestAttack, WpsCampaign, EvilTwinCampaign]
+_BUTTON_ORDER = ["btn-gen-ivs", "btn-chop", "btn-deauth", "btn-pmkid", "btn-wps-pin", "btn-eviltwin"]
 
 
 @dataclass

--- a/src/wifit3/ui/screens/focus_v2/screen.py
+++ b/src/wifit3/ui/screens/focus_v2/screen.py
@@ -84,8 +84,8 @@ _PAD_RATE = 0.4
 _PBC_RETRY_COOLDOWN_S = 3.0
 
 _ATTACK_BUTTONS = [
-    ("btn-gen-ivs", "ARP Replay"), ("btn-chop", "ChopChop"), ("btn-pmkid", "PMKID"),
-    ("btn-deauth", "Deauth"), ("btn-wps-pin", "WPS PIN"), ("btn-eviltwin", "EvilTwin"),
+    ("btn-gen-ivs", "ARP Replay"), ("btn-chop", "ChopChop"), ("btn-deauth", "AutoDeauth"),
+    ("btn-pmkid", "PMKID"), ("btn-wps-pin", "WPS PIN"), ("btn-eviltwin", "EvilTwin"),
     ("btn-stop-pbc", "Stop PBC"),
 ]
 
@@ -134,6 +134,7 @@ class FocusViewV2(Screen):
     # Attack hotkeys come from the campaign registry
     BINDINGS = [
         Binding("escape", "go_back", "Back", show=True),
+        Binding("d", "deauth_all", "Deauth", show=True),
         *[Binding(cls.hotkey[0], f"campaign('{cls.key}')", cls.hotkey[1], show=True)
           for cls in fm.BUTTON_CAMPAIGNS if cls.hotkey],
         Binding("c", "campaign('chop')", "ChopChop", show=True),
@@ -653,6 +654,10 @@ class FocusViewV2(Screen):
             if st is None or not st.visible:
                 return False
             return None if st.disabled else True
+        if action == "deauth_all":
+            if ap is None:
+                return False
+            return None if fm.deauth_blocked(ap) else True
         return True
 
     def _sync_bindings(self) -> None:
@@ -674,6 +679,10 @@ class FocusViewV2(Screen):
         if toggle is not None:
             toggle()
         self._sync_bindings()
+
+    def action_deauth_all(self) -> None:
+        """'d': one-shot broadcast deauth, matching the client-panel button."""
+        self.run_worker(self._run_deauth_broadcast(), exclusive=True)
 
     def action_wps_pbc_mode(self) -> None:
         """'w': toggle the shared WPS PBC auto-invade."""

--- a/tests/ui/test_focus_model.py
+++ b/tests/ui/test_focus_model.py
@@ -270,7 +270,7 @@ def _bs(b):
 def test_buttons_wpa2_psk_no_wps_pmkid_and_deauth_visible():
     b = fm.derive_buttons(_rsn_ap(akms=("PSK",), wps=False))
     assert _bs(b["btn-pmkid"]) == (True, False, "PMKID", "primary")
-    assert _bs(b["btn-deauth"]) == (True, False, "Deauth", "primary")
+    assert _bs(b["btn-deauth"]) == (True, False, "Auto Deauth", "primary")
     assert b["btn-wps-pin"].visible is False
     assert b["btn-gen-ivs"].visible is False and b["btn-chop"].visible is False
 

--- a/tests/ui/test_focus_model.py
+++ b/tests/ui/test_focus_model.py
@@ -270,7 +270,7 @@ def _bs(b):
 def test_buttons_wpa2_psk_no_wps_pmkid_and_deauth_visible():
     b = fm.derive_buttons(_rsn_ap(akms=("PSK",), wps=False))
     assert _bs(b["btn-pmkid"]) == (True, False, "PMKID", "primary")
-    assert _bs(b["btn-deauth"]) == (True, False, "Auto Deauth", "primary")
+    assert _bs(b["btn-deauth"]) == (True, False, "AutoDeauth", "primary")
     assert b["btn-wps-pin"].visible is False
     assert b["btn-gen-ivs"].visible is False and b["btn-chop"].visible is False
 

--- a/tests/ui/test_focus_v2_hotkeys.py
+++ b/tests/ui/test_focus_v2_hotkeys.py
@@ -142,23 +142,25 @@ async def _rebind(host, array, ap):
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_deauth_campaign_key_visible_on_psk_hidden_on_pmf(focus_host):
-    """'d' now toggles the Deauth campaign (the one-shot 'Deauth all' button keeps
-    its click but loses the key): active on WPA2-PSK with no clients (True, it can
-    still broadcast), still active once a client appears (True), and HIDDEN (False,
-    not greyed) once the AP requires PMF, which protects the deauth."""
+async def test_deauth_keys_visible_on_psk_blocked_on_pmf(focus_host):
+    """'d' is the one-shot broadcast deauth; Shift+D toggles the automatic
+    deauth campaign. Both are active on WPA2-PSK and blocked once PMF protects
+    deauth frames."""
     bssid, client = "aa:bb:cc:dd:ee:01", "9c:b6:d0:1a:2b:3c"
     iface, array, ap = _wpa2_target(bssid)
     focus = await _rebind(focus_host, array, ap)
     focus._tick()
-    assert focus.check_action("campaign", ("deauth",)) is True    # no clients → still active
+    assert focus.check_action("deauth_all", ()) is True           # manual broadcast
+    assert focus.check_action("campaign", ("deauth",)) is True    # automatic campaign
 
     iface._on_frame_parsed(_client_data(bssid, client))
     focus._tick()
-    assert focus.check_action("campaign", ("deauth",)) is True    # a client → active
+    assert focus.check_action("deauth_all", ()) is True           # still active with a client
+    assert focus.check_action("campaign", ("deauth",)) is True
 
     ap.pmf_required = True
     focus._tick()
+    assert focus.check_action("deauth_all", ()) is None           # PMF → visible but greyed
     assert focus.check_action("campaign", ("deauth",)) is False   # PMF → hidden
 
 
@@ -186,9 +188,9 @@ async def test_deauth_broadcast_button_always_visible(focus_host):
 
 @pytest.mark.asyncio(loop_scope="module")
 async def test_campaign_hotkeys_mirror_buttons_wpa2(focus_host):
-    """On a plain WPA2 AP (no WPS, not WPA3): PMKID and Deauth are the plausible
-    attacks, so 'p' and 'd' are active and every other campaign key is hidden,
-    exactly the button row's visibility (test_v2_button_wiring)."""
+    """On a plain WPA2 AP (no WPS, not WPA3): PMKID and automatic Deauth are
+    plausible campaigns, so 'p' and Shift+D are active and every other campaign
+    key is hidden, exactly the button row's visibility (test_v2_button_wiring)."""
     iface, array, ap = _wpa2_target()
     focus = await _rebind(focus_host, array, ap)
     focus._tick()
@@ -245,8 +247,9 @@ async def test_footer_shows_campaign_keys_per_family():
                 break
         assert "p" in keys
         assert "r" not in keys and "c" not in keys
-        # 'd' now toggles the Deauth campaign (visible on WPA2-PSK); 'w' always available.
+        # 'd' is manual broadcast deauth; Shift+D toggles the Deauth campaign.
         assert "w" in keys and "d" in keys
+        assert "D" in keys
 
 
 @pytest.mark.asyncio(loop_scope="module")
@@ -261,6 +264,28 @@ async def test_deauth_button_click_routes_to_campaign_toggle(focus_host, monkeyp
     monkeypatch.setattr(focus, "_toggle_deauth", lambda: fired.append("deauth"))
     await focus.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="btn-deauth")))
     assert fired == ["deauth"]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_action_deauth_all_dispatches_manual_broadcast(focus_host, monkeypatch):
+    """The plain 'd' key starts the one-shot broadcast deauth worker, not the
+    automatic DeauthCampaign toggle."""
+    iface, array, ap = _wpa2_target()
+    focus = await _rebind(focus_host, array, ap)
+    fired = []
+
+    async def _manual():
+        pass
+
+    monkeypatch.setattr(focus, "_run_deauth_broadcast", _manual)
+
+    def _record_worker(coro, **kwargs):
+        fired.append(kwargs)
+        coro.close()
+
+    monkeypatch.setattr(focus, "run_worker", _record_worker)
+    focus.action_deauth_all()
+    assert fired == [{"exclusive": True}]
 
 
 @pytest.mark.asyncio(loop_scope="module")


### PR DESCRIPTION
Switched back old behaviour and kept new button behaviour under shift + d (or uppercase D) + renamed the button to "Auto Deauth" to remove confusion betwen these two. Side of this change is swapped deauth button with pmkid button, i hope its okay, as it makes sense in the chronological order that attacks are ussualy done, but possible to fix if needed.