### PR TITLE
ui(themes): theming patches

### DIFF
--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,115 @@
+# Themes
+
+Wifit3 can register additional Textual themes from TOML files.
+
+- Built-in Wifit3 themes live in `src/wifit3/ui/themes/`.
+- User themes live in the platform config directory under `themes/`.
+  - Linux example: `~/.config/wifit3/themes/`
+
+Themes are registered before the saved `theme` preference is applied, so a config value can point at a user-defined theme name. During theme development, run Wifit3 with `--theme-reload` to reload changed theme files while the TUI is running.
+
+## Schema
+
+```toml
+schema = 1
+
+[theme]
+name = "wifit3-green"
+display_name = "Wifit3 Green"
+dark = true
+
+[colors]
+primary = "#00ff88"
+secondary = "#00c8ff"
+accent = "#00ff88"
+foreground = "#d8ffe8"
+background = "#050805"
+surface = "#0b120b"
+panel = "#101810"
+success = "#00ff88"
+warning = "#ffd75f"
+error = "#ff5f5f"
+
+[variables]
+logo_color_primary = "#00ff88"
+logo_color_secondary = "#008f55"
+logo_text_primary = "#f4fff8"
+logo_text_secondary = "#7aa88a"
+```
+
+## Required fields
+
+```toml
+schema = 1
+
+[theme]
+name = "my-theme"
+```
+
+`[theme].dark` is optional and defaults to `true`.
+
+## Supported color keys
+
+The `[colors]` table accepts:
+
+```text
+primary
+secondary
+warning
+error
+success
+accent
+foreground
+background
+surface
+panel
+boost
+```
+
+`primary` defaults to Wifit3 green (`#00ff88`) when omitted. Other missing colors are left for Textual to derive/default.
+
+Theme colors may use Rich/Textual color names or hex values. Wifit3 also normalizes compact hex forms before handing them to Textual:
+
+```text
+#x        -> #xxxxxx          grayscale nibble
+#xx       -> #xxxxxx          grayscale byte
+#rgb      -> #rrggbb          CSS shorthand
+#rgba     -> #rrggbb          CSS shorthand; alpha ignored
+#rrggbbaa -> #rrggbb          alpha ignored
+```
+
+Examples: `#0f` becomes `#0f0f0f`, `#abc` becomes `#aabbcc`, and `#abcd` becomes `#aabbcc`.
+
+## Logo colors
+
+Splash logo ANSI art has four replaceable palette slots. Define them in `[variables]`:
+
+```toml
+[variables]
+logo_color_primary = "#00ff88"
+logo_color_secondary = "#008f55"
+logo_text_primary = "#f4fff8"
+logo_text_secondary = "#7aa88a"
+```
+
+Missing logo variables fall back to Wifit3's default logo palette for the active Textual theme mode: dark themes keep the original bright green logo, while light themes use darker ink-friendly logo colors.
+
+## Loader behavior
+
+- Unknown keys are ignored.
+- Invalid TOML files are skipped and logged.
+- Invalid color strings skip that theme.
+- User themes are registered after built-in Wifit3 themes, so a user theme can override a Wifit3 theme name intentionally.
+- Built-in Textual themes are not modified by Wifit3.
+
+## Live reload
+
+Live theme reload is opt-in so normal runs keep the dependency/runtime surface minimal:
+
+```bash
+uv run wifit3 --theme-reload
+```
+
+With `--theme-reload`, the app checks built-in and user theme `.toml` files once per second. When a file changes, Wifit3 re-registers the available themes and re-applies the active theme, so color edits should show up without restarting the TUI.
+
+If a file is invalid while you are editing it, Wifit3 keeps running, skips that file, and shows a warning toast. Save a valid TOML file again and it will be picked up on the next reload tick.

--- a/src/wifit3/__main__.py
+++ b/src/wifit3/__main__.py
@@ -53,6 +53,9 @@ def main() -> None:
     parser.add_argument(
         "--smoke", action="store_true",
         help="Boot the TUI headless, render one frame, and exit 0 (CI bundling self-test).")
+    parser.add_argument(
+        "--theme-reload", action="store_true",
+        help="Developer mode: poll theme TOML files and reload changed themes while running.")
     args = parser.parse_args()
 
     if args.smoke:
@@ -69,7 +72,7 @@ def main() -> None:
 
     # Released builds default to a DEBUG wifit3.log so field bug reports arrive with a
     # trace already captured; WIFIT3_LOG=off opts out, =trace bumps to the firehose.
-    WifiteApp(default_log_level="debug").run()
+    WifiteApp(default_log_level="debug", theme_reload=args.theme_reload).run()
 
 
 if __name__ == "__main__":

--- a/src/wifit3/persist/config.py
+++ b/src/wifit3/persist/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 _PATH = Path(user_config_dir("wifit3", appauthor=False)) / "config.toml"
+DEFAULT_THEME = "wifit3-green-dark"
 
 
 class ConfigError(Exception):
@@ -14,7 +15,7 @@ class ConfigError(Exception):
 
 
 class Config:
-    theme: str = "textual-dark"
+    theme: str = DEFAULT_THEME
     scanner_sort: str = "signal"
     scanner_sort_reverse: bool = True
     silenced_bssids: list[str] = []

--- a/src/wifit3/persist/config.py
+++ b/src/wifit3/persist/config.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from platformdirs import user_config_dir
 
 _PATH = Path(user_config_dir("wifit3", appauthor=False)) / "config.toml"
-DEFAULT_THEME = "wifit3-green-dark"
 
 
 class ConfigError(Exception):
@@ -15,7 +14,7 @@ class ConfigError(Exception):
 
 
 class Config:
-    theme: str = DEFAULT_THEME
+    theme: str = "textual-dark"
     scanner_sort: str = "signal"
     scanner_sort_reverse: bool = True
     silenced_bssids: list[str] = []

--- a/src/wifit3/ui/ansi_art.py
+++ b/src/wifit3/ui/ansi_art.py
@@ -13,6 +13,24 @@ from rich.style import Style
 from rich.text import Text
 
 _BLACK = (0, 0, 0)
+_LOGO_COLOR_MAP = {
+    (0, 255, 0): "logo_color_primary",
+    (0, 128, 0): "logo_color_secondary",
+    (255, 255, 255): "logo_text_primary",
+    (128, 128, 128): "logo_text_secondary",
+}
+_LOGO_DARK_DEFAULTS = {
+    "logo_color_primary": "#00ff00",
+    "logo_color_secondary": "#008000",
+    "logo_text_primary": "#ffffff",
+    "logo_text_secondary": "#808080",
+}
+_LOGO_LIGHT_DEFAULTS = {
+    "logo_color_primary": "#00bb00",
+    "logo_color_secondary": "#008000",
+    "logo_text_primary": "#111111",
+    "logo_text_secondary": "#666666",
+}
 _CONSOLE = Console()          # only for get_style_at_offset; never writes output
 
 
@@ -20,16 +38,55 @@ def is_black(color: Color | None) -> bool:
     return color is not None and color.triplet is not None and tuple(color.triplet) == _BLACK
 
 
-def _without_bgcolor(style: Style) -> Style:
-    """``style`` with the background unset (preserving fg + text attributes)."""
+def _style_like(style: Style, *, color: Color | str | None, bgcolor: Color | str | None) -> Style:
     return Style(
-        color=style.color,
+        color=color, bgcolor=bgcolor,
         bold=style.bold, dim=style.dim, italic=style.italic,
         underline=style.underline, blink=style.blink, blink2=style.blink2,
         reverse=style.reverse, conceal=style.conceal, strike=style.strike,
         underline2=style.underline2, frame=style.frame,
         encircle=style.encircle, overline=style.overline, link=style.link,
     )
+
+
+def _without_bgcolor(style: Style) -> Style:
+    """``style`` with the background unset (preserving fg + text attributes)."""
+    return _style_like(style, color=style.color, bgcolor=None)
+
+
+def _mapped_logo_color(
+    color: Color | None,
+    variables: dict[str, str],
+    defaults: dict[str, str],
+) -> Color | str | None:
+    if color is None or color.triplet is None:
+        return color
+    key = _LOGO_COLOR_MAP.get(tuple(color.triplet))
+    return variables.get(key, defaults.get(key, color)) if key else color
+
+
+def recolor_logo(text: Text, variables: dict[str, str], *, dark: bool = True) -> Text:
+    """Replace the logo's four baked ANSI colors with theme-provided logo variables.
+
+    Supported variables: ``logo_color_primary``, ``logo_color_secondary``,
+    ``logo_text_primary`` and ``logo_text_secondary``. Missing variables use a
+    dark/light fallback palette matching Textual's active theme mode.
+    """
+    defaults = _LOGO_DARK_DEFAULTS if dark else _LOGO_LIGHT_DEFAULTS
+    out = text.copy()
+    spans = []
+    for span in out.spans:
+        style = Style.parse(span.style) if isinstance(span.style, str) else span.style
+        if not isinstance(style, Style):
+            spans.append(span)
+            continue
+        spans.append(span._replace(style=_style_like(
+            style,
+            color=_mapped_logo_color(style.color, variables, defaults),
+            bgcolor=_mapped_logo_color(style.bgcolor, variables, defaults),
+        )))
+    out.spans = spans
+    return out
 
 
 def make_black_transparent(text: Text, *, blank_black_ink: bool = False) -> Text:

--- a/src/wifit3/ui/ansi_art.py
+++ b/src/wifit3/ui/ansi_art.py
@@ -66,12 +66,7 @@ def _mapped_logo_color(
 
 
 def recolor_logo(text: Text, variables: dict[str, str], *, dark: bool = True) -> Text:
-    """Replace the logo's four baked ANSI colors with theme-provided logo variables.
-
-    Supported variables: ``logo_color_primary``, ``logo_color_secondary``,
-    ``logo_text_primary`` and ``logo_text_secondary``. Missing variables use a
-    dark/light fallback palette matching Textual's active theme mode.
-    """
+    """Replace the logo's baked ANSI palette with theme logo variables."""
     defaults = _LOGO_DARK_DEFAULTS if dark else _LOGO_LIGHT_DEFAULTS
     out = text.copy()
     spans = []
@@ -90,12 +85,7 @@ def recolor_logo(text: Text, variables: dict[str, str], *, dark: bool = True) ->
 
 
 def make_black_transparent(text: Text, *, blank_black_ink: bool = False) -> Text:
-    """Drop pure-black backgrounds so ``text`` inherits the theme surface.
-
-    With ``blank_black_ink`` also blank black-foreground glyphs, for art that
-    draws *with* black ink, not just on a black canvas (the Focus endpoint art).
-    Without it, black ink is kept (the Splash logo draws in colour on a black
-    canvas, so only the canvas is dropped)."""
+    """Drop pure-black backgrounds so ``text`` inherits the theme surface."""
     if not blank_black_ink:
         out = text.copy()
         out.spans = [

--- a/src/wifit3/ui/app.py
+++ b/src/wifit3/ui/app.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from textual import work
-from textual.app import App
+from textual.app import App, InvalidThemeError
 from typing import Optional
 
 from wifit3.chips import log_trace
@@ -18,6 +18,7 @@ from .screens.scanner import ScannerView
 from .screens.focus_v2 import FocusViewV2
 from .screens.error_modals import FatalErrorModal, RecoverableErrorModal
 from .screens.new_device import NewDeviceDialog
+from .themes import ThemeFilePoller, register_app_themes
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,7 @@ class WifiteApp(App):
     EvilTwinInputModal #bssid-btns Button { min-width: 4; }
     """
 
-    def __init__(self, default_log_level: Optional[str] = None):
+    def __init__(self, default_log_level: Optional[str] = None, *, theme_reload: bool = False):
         _configure_file_logging(default_log_level)
         super().__init__()
         self.array: Optional[WlanArray] = None
@@ -141,7 +142,46 @@ class WifiteApp(App):
         # both read/toggle it via 'w'). On by default: the one active-TX exception
         # to passive-by-default (auto-captures a PSK when any AP's button is pressed).
         self.pbc_enabled: bool = True
-        self.theme = Config.theme
+        self.theme_reload = theme_reload
+        self._theme_poller = ThemeFilePoller()
+        self._theme_timer = None
+        register_app_themes(self)
+        self._theme_poller.start()
+        self._apply_config_theme()
+
+    def _apply_config_theme(self) -> None:
+        try:
+            self.theme = Config.theme
+        except InvalidThemeError:
+            bad = Config.theme
+            Config.theme = "textual-dark"
+            self.theme = Config.theme
+            try:
+                Config.save()
+            except ConfigError as e:
+                self._config_error = str(e)
+            else:
+                self._config_error = f"Unknown theme {bad!r}; reset to textual-dark."
+        self._refresh_theme_dependents()
+
+    def _reload_themes_if_changed(self) -> None:
+        result = self._theme_poller.reload_if_changed(self)
+        if not result.changed:
+            return
+        self._apply_config_theme()
+        if result.skipped:
+            self.notify(
+                f"Skipped invalid theme file(s): {', '.join(result.skipped)}",
+                severity="warning", title="Themes",
+            )
+        elif result.registered:
+            self.notify("Theme file changes reloaded.", severity="information", title="Themes")
+
+    def _refresh_theme_dependents(self) -> None:
+        for screen in self.screen_stack:
+            refresh = getattr(screen, "refresh_theme_art", None)
+            if refresh is not None:
+                refresh()
 
     def persist_config(self) -> None:
         try:
@@ -153,6 +193,7 @@ class WifiteApp(App):
         if theme != Config.theme:
             Config.theme = theme
             self.persist_config()
+        self._refresh_theme_dependents()
 
     def on_mount(self) -> None:
         """Register screens, push the splash, and start the always-on device watch."""
@@ -163,6 +204,8 @@ class WifiteApp(App):
         self.install_screen(FocusViewV2(), name="focus")
         self.push_screen("splash")
         self._device_timer = self.set_interval(0.5, self.device_watch.poll)
+        if self.theme_reload:
+            self._theme_timer = self.set_interval(1.0, self._reload_themes_if_changed)
         self.call_after_refresh(self.device_watch.poll)
 
     def _on_devices_changed(self, current, arrived, departed) -> None:

--- a/src/wifit3/ui/app.py
+++ b/src/wifit3/ui/app.py
@@ -6,7 +6,7 @@ from textual.app import App, InvalidThemeError
 from typing import Optional
 
 from wifit3.chips import log_trace
-from wifit3.persist.config import DEFAULT_THEME, Config, ConfigError
+from wifit3.persist.config import Config, ConfigError
 from wifit3.errors import WifiteDeviceLostError, WifiteFatalError
 from wifit3.device.manager import DeviceManager, Status
 from wifit3.device.watch import DeviceWatch
@@ -154,14 +154,14 @@ class WifiteApp(App):
             self.theme = Config.theme
         except InvalidThemeError:
             bad = Config.theme
-            Config.theme = DEFAULT_THEME
+            Config.theme = "textual-dark"
             self.theme = Config.theme
             try:
                 Config.save()
             except ConfigError as e:
                 self._config_error = str(e)
             else:
-                self._config_error = f"Unknown theme {bad!r}; reset to {DEFAULT_THEME}."
+                self._config_error = f"Unknown theme {bad!r}; reset to textual-dark."
         self._refresh_theme_dependents()
 
     def _reload_themes_if_changed(self) -> None:

--- a/src/wifit3/ui/app.py
+++ b/src/wifit3/ui/app.py
@@ -6,7 +6,7 @@ from textual.app import App, InvalidThemeError
 from typing import Optional
 
 from wifit3.chips import log_trace
-from wifit3.persist.config import Config, ConfigError
+from wifit3.persist.config import DEFAULT_THEME, Config, ConfigError
 from wifit3.errors import WifiteDeviceLostError, WifiteFatalError
 from wifit3.device.manager import DeviceManager, Status
 from wifit3.device.watch import DeviceWatch
@@ -154,14 +154,14 @@ class WifiteApp(App):
             self.theme = Config.theme
         except InvalidThemeError:
             bad = Config.theme
-            Config.theme = "textual-dark"
+            Config.theme = DEFAULT_THEME
             self.theme = Config.theme
             try:
                 Config.save()
             except ConfigError as e:
                 self._config_error = str(e)
             else:
-                self._config_error = f"Unknown theme {bad!r}; reset to textual-dark."
+                self._config_error = f"Unknown theme {bad!r}; reset to {DEFAULT_THEME}."
         self._refresh_theme_dependents()
 
     def _reload_themes_if_changed(self) -> None:

--- a/src/wifit3/ui/screens/splash.py
+++ b/src/wifit3/ui/screens/splash.py
@@ -13,7 +13,7 @@ from rich.text import Text
 
 from typing import TYPE_CHECKING
 
-from wifit3.ui.ansi_art import make_black_transparent
+from wifit3.ui.ansi_art import make_black_transparent, recolor_logo
 from wifit3.ui.screens.setup_error import SetupErrorDialog
 from wifit3.device.manager import Status
 
@@ -106,7 +106,7 @@ class SplashView(Screen):
         yield Header(show_clock=False)
         with Vertical(id="splash-container"):
             with Center():
-                yield Static(LOGO, id="ascii-art")
+                yield Static(self._logo(), id="ascii-art")
             with Center():
                 yield Label("Scanning for compatible hardware…", id="status-label")
             with Center():
@@ -130,6 +130,14 @@ class SplashView(Screen):
         checkbox list shown for 2+. render_devices displays exactly one at a time."""
         return (self.query_one("#device-list", ListView),
                 self.query_one("#device-select", SelectionList))
+
+    def _logo(self) -> Text:
+        theme = self.app.current_theme
+        return recolor_logo(LOGO, theme.variables, dark=theme.dark)
+
+    def refresh_theme_art(self) -> None:
+        logo = self.query_one("#ascii-art", Static)
+        logo.update(self._logo())
 
     def _enter_scanning_mode(self) -> None:
         """The 'pick a card' resting state."""

--- a/src/wifit3/ui/themes.py
+++ b/src/wifit3/ui/themes.py
@@ -1,0 +1,189 @@
+"""Textual theme loading for Wifit3.
+
+Built-in Wifit3 themes live as TOML files in ``ui/themes/``; user themes live in
+``<platform config dir>/themes/``. See ``docs/THEMES.md`` for the schema. Invalid user themes are
+skipped and logged; they must never break app startup.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import tomllib
+from typing import Any
+
+from platformdirs import user_config_dir
+from rich.color import Color, ColorParseError
+from textual.theme import Theme
+
+logger = logging.getLogger(__name__)
+
+BUILTIN_THEMES_DIR = Path(__file__).with_name("themes")
+USER_THEMES_DIR = Path(user_config_dir("wifit3", appauthor=False)) / "themes"
+_SCHEMA = 1
+_DEFAULT_PRIMARY = "#00ff88"
+_COLOR_KEYS = {
+    "primary", "secondary", "warning", "error", "success", "accent", "foreground",
+    "background", "surface", "panel", "boost",
+}
+
+
+@dataclass(frozen=True)
+class ThemeReloadResult:
+    changed: bool
+    registered: tuple[str, ...] = ()
+    skipped: tuple[str, ...] = ()
+
+
+class ThemeFilePoller:
+    def __init__(self, *, user_dir: Path | None = None):
+        self.user_dir = user_dir or USER_THEMES_DIR
+        self._snapshot: dict[Path, int | None] = {}
+
+    def start(self) -> None:
+        self._snapshot = self._scan()
+
+    def reload_if_changed(self, app) -> ThemeReloadResult:
+        snapshot = self._scan()
+        if snapshot == self._snapshot:
+            return ThemeReloadResult(changed=False)
+        self._snapshot = snapshot
+        return register_app_themes(app, user_dir=self.user_dir)
+
+    def _scan(self) -> dict[Path, int | None]:
+        paths = [*_theme_files(BUILTIN_THEMES_DIR), *_theme_files(self.user_dir)]
+        return {path: _mtime_ns(path) for path in paths}
+
+
+def register_app_themes(app, *, user_dir: Path | None = None) -> ThemeReloadResult:
+    """Register packaged Wifit3 themes, then user-defined themes.
+
+    User themes are registered second so a user may intentionally override a Wifit3 theme name.
+    Built-in Textual themes are owned by Textual and are not touched here.
+    """
+    registered: list[str] = []
+    skipped: list[str] = []
+    for path in _theme_files(BUILTIN_THEMES_DIR):
+        _register_theme_file(app, path, registered, skipped)
+    for path in _theme_files(user_dir or USER_THEMES_DIR):
+        _register_theme_file(app, path, registered, skipped)
+    return ThemeReloadResult(
+        changed=bool(registered or skipped),
+        registered=tuple(registered), skipped=tuple(skipped),
+    )
+
+
+def _theme_files(path: Path) -> list[Path]:
+    try:
+        return sorted(p for p in path.glob("*.toml") if p.is_file())
+    except OSError as exc:
+        logger.warning("Failed to scan theme directory %s: %s", path, exc)
+        return []
+
+
+def _mtime_ns(path: Path) -> int | None:
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _register_theme_file(
+    app,
+    path: Path,
+    registered: list[str] | None = None,
+    skipped: list[str] | None = None,
+) -> None:
+    try:
+        theme = load_theme_file(path)
+        app.register_theme(theme)
+        if registered is not None:
+            registered.append(theme.name)
+    except ThemeLoadError as exc:
+        logger.warning("Skipping theme %s: %s", path, exc)
+        if skipped is not None:
+            skipped.append(path.name)
+
+
+class ThemeLoadError(Exception):
+    pass
+
+
+def load_theme_file(path: Path) -> Theme:
+    """Load one schema-v1 TOML theme file into a Textual ``Theme``."""
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ThemeLoadError(str(exc)) from exc
+    if not isinstance(data, dict):
+        raise ThemeLoadError("theme file must be a TOML table")
+    schema = data.get("schema", _SCHEMA)
+    if schema != _SCHEMA:
+        raise ThemeLoadError(f"unsupported schema {schema!r}")
+    theme = data.get("theme")
+    colors = data.get("colors", {})
+    variables = data.get("variables", {})
+    if not isinstance(theme, dict):
+        raise ThemeLoadError("missing [theme] table")
+    if not isinstance(colors, dict):
+        raise ThemeLoadError("[colors] must be a table")
+    if not isinstance(variables, dict):
+        raise ThemeLoadError("[variables] must be a table")
+
+    name = _string(theme.get("name"))
+    if name is None:
+        raise ThemeLoadError("[theme].name is required")
+    dark = theme.get("dark", True)
+    if not isinstance(dark, bool):
+        raise ThemeLoadError("[theme].dark must be true or false")
+
+    kwargs: dict[str, Any] = {"name": name, "dark": dark}
+    for key in _COLOR_KEYS:
+        raw = colors.get(key)
+        if raw is None and key == "primary":
+            raw = _DEFAULT_PRIMARY
+        if raw is None:
+            continue
+        color = _color(raw, f"colors.{key}")
+        kwargs[key] = color
+    kwargs["variables"] = {
+        str(key): _color(value, f"variables.{key}")
+        for key, value in variables.items()
+    }
+    return Theme(**kwargs)
+
+
+def _string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _color(value: object, key: str) -> str:
+    color = _string(value)
+    if color is None:
+        raise ThemeLoadError(f"{key} must be a color string")
+    color = _normalize_hex_color(color)
+    try:
+        Color.parse(color)
+    except ColorParseError as exc:
+        raise ThemeLoadError(f"{key} is not a valid color: {color}") from exc
+    return color
+
+
+def _normalize_hex_color(color: str) -> str:
+    if not color.startswith("#"):
+        return color
+    raw = color[1:]
+    if not raw or any(ch not in "0123456789abcdefABCDEF" for ch in raw):
+        return color
+    if len(raw) == 1:
+        return f"#{raw * 6}"
+    if len(raw) == 2:
+        return f"#{raw * 3}"
+    if len(raw) in (3, 4):
+        return "#" + "".join(ch * 2 for ch in raw[:3])
+    if len(raw) == 8:
+        return f"#{raw[:6]}"
+    return color

--- a/src/wifit3/ui/themes.py
+++ b/src/wifit3/ui/themes.py
@@ -26,6 +26,8 @@ _COLOR_KEYS = {
     "primary", "secondary", "warning", "error", "success", "accent", "foreground",
     "background", "surface", "panel", "boost",
 }
+# Removes matching registered themes from Wifit3's available theme list.
+BLACKLISTED_THEME_NAMES: list[str] = []
 
 
 @dataclass(frozen=True)
@@ -59,7 +61,8 @@ def register_app_themes(app, *, user_dir: Path | None = None) -> ThemeReloadResu
     """Register packaged Wifit3 themes, then user-defined themes.
 
     User themes are registered second so a user may intentionally override a Wifit3 theme name.
-    Built-in Textual themes are owned by Textual and are not touched here.
+    Built-in Textual themes are owned by Textual. Hardcoded Wifit3-blacklisted themes are
+    removed after registration.
     """
     registered: list[str] = []
     skipped: list[str] = []
@@ -67,10 +70,25 @@ def register_app_themes(app, *, user_dir: Path | None = None) -> ThemeReloadResu
         _register_theme_file(app, path, registered, skipped)
     for path in _theme_files(user_dir or USER_THEMES_DIR):
         _register_theme_file(app, path, registered, skipped)
+    unregister_blacklisted_themes(app)
     return ThemeReloadResult(
         changed=bool(registered or skipped),
         registered=tuple(registered), skipped=tuple(skipped),
     )
+
+
+def is_theme_blacklisted(name: str) -> bool:
+    return name in BLACKLISTED_THEME_NAMES
+
+
+def unregister_blacklisted_themes(app) -> None:
+    themes = getattr(app, "_registered_themes", None)
+    if themes is None:
+        themes = getattr(app, "available_themes", None)
+    if themes is None:
+        return
+    for name in BLACKLISTED_THEME_NAMES:
+        themes.pop(name, None)
 
 
 def _theme_files(path: Path) -> list[Path]:

--- a/src/wifit3/ui/themes.py
+++ b/src/wifit3/ui/themes.py
@@ -58,12 +58,7 @@ class ThemeFilePoller:
 
 
 def register_app_themes(app, *, user_dir: Path | None = None) -> ThemeReloadResult:
-    """Register packaged Wifit3 themes, then user-defined themes.
-
-    User themes are registered second so a user may intentionally override a Wifit3 theme name.
-    Built-in Textual themes are owned by Textual. Hardcoded Wifit3-blacklisted themes are
-    removed after registration.
-    """
+    """Register packaged Wifit3 themes, then user-defined themes."""
     registered: list[str] = []
     skipped: list[str] = []
     for path in _theme_files(BUILTIN_THEMES_DIR):

--- a/src/wifit3/ui/themes/wifit3-green-dark.toml
+++ b/src/wifit3/ui/themes/wifit3-green-dark.toml
@@ -1,0 +1,30 @@
+schema = 1
+
+[theme]
+name = "wifit3-green-dark"
+display_name = "Wifit3 Green Dark"
+dark = true
+
+[colors]
+primary = "#00ff88"
+secondary = "#00c8ff"
+accent = "#00ff88"
+foreground = "#d8ffe8"
+background = "#050805"
+surface = "#0b120b"
+panel = "#101810"
+success = "#00ff88"
+warning = "#ffd75f"
+error = "#ff5f5f"
+
+[variables]
+block-cursor-background = "#00ff88"
+block-cursor-blurred-background = "#1f5f3f"
+block-hover-background = "#163322"
+input-selection-background = "#005f3a"
+screen-selection-background = "#007a48"
+
+logo_color_primary = "#00ff22"
+logo_color_secondary = "#008f22"
+logo_text_primary = "#f4fff8"
+logo_text_secondary = "#7aa88a"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ def config_path(tmp_path, monkeypatch):
 
 def test_load_missing_file_keeps_defaults(config_path):
     Config.load()
-    assert Config.theme == "textual-dark"
+    assert Config.theme == DEFAULT_THEME
     assert Config.scanner_sort == "signal"
     assert Config.scanner_sort_reverse is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,20 @@
 import pytest
 
 import wifit3.persist.config as cfg
-from wifit3.persist.config import DEFAULT_THEME, Config, ConfigError
+from wifit3.persist.config import Config, ConfigError
 
 
 @pytest.fixture(autouse=True)
 def _restore_defaults():
-    keys = ("theme", "scanner_sort", "scanner_sort_reverse", "silenced_bssids")
-    saved = {k: getattr(Config, k) for k in keys}
+    Config.theme = DEFAULT_THEME
+    Config.scanner_sort = "signal"
+    Config.scanner_sort_reverse = True
+    Config.silenced_bssids = []
     yield
-    for k, v in saved.items():
-        setattr(Config, k, list(v) if isinstance(v, list) else v)
+    Config.theme = DEFAULT_THEME
+    Config.scanner_sort = "signal"
+    Config.scanner_sort_reverse = True
+    Config.silenced_bssids = []
 
 
 @pytest.fixture
@@ -22,7 +26,7 @@ def config_path(tmp_path, monkeypatch):
 
 def test_load_missing_file_keeps_defaults(config_path):
     Config.load()
-    assert Config.theme == DEFAULT_THEME
+    assert Config.theme == "textual-dark"
     assert Config.scanner_sort == "signal"
     assert Config.scanner_sort_reverse is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 
 import wifit3.persist.config as cfg
-from wifit3.persist.config import Config, ConfigError
+from wifit3.persist.config import DEFAULT_THEME, Config, ConfigError
 
 
 @pytest.fixture(autouse=True)
@@ -22,7 +22,7 @@ def config_path(tmp_path, monkeypatch):
 
 def test_load_missing_file_keeps_defaults(config_path):
     Config.load()
-    assert Config.theme == "textual-dark"
+    assert Config.theme == DEFAULT_THEME
     assert Config.scanner_sort == "signal"
     assert Config.scanner_sort_reverse is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 
 import wifit3.persist.config as cfg
-from wifit3.persist.config import Config, ConfigError
+from wifit3.persist.config import DEFAULT_THEME, Config, ConfigError
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wifit3.persist.config import DEFAULT_THEME, Config
+from wifit3.persist.config import Config
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.screens.splash import SplashView
 from wifit3.ui.screens.scanner import ScannerView
@@ -46,7 +46,7 @@ async def test_app_layout_and_boot():
 def test_app_refreshes_theme_art_when_theme_changes(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
-    Config.theme = DEFAULT_THEME
+    Config.theme = "textual-dark"
     app = WifiteApp()
     refreshed = []
     monkeypatch.setattr(app, "_refresh_theme_dependents", lambda: refreshed.append(True))
@@ -62,11 +62,12 @@ def test_app_resets_invalid_saved_theme(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text("theme = 'missing-theme'\n", encoding="utf-8")
     monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
-    Config.theme = DEFAULT_THEME
+    Config.theme = "textual-dark"
 
     app = WifiteApp()
 
-    assert app.theme == DEFAULT_THEME
-    assert Config.theme == DEFAULT_THEME
-    assert f"theme = '{DEFAULT_THEME}'" in config_path.read_text(encoding="utf-8")
+    assert app.theme == "textual-dark"
+    assert Config.theme == "textual-dark"
+    assert "theme = 'textual-dark'" in config_path.read_text(encoding="utf-8")
+
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wifit3.persist.config import Config
+from wifit3.persist.config import DEFAULT_THEME, Config
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.screens.splash import SplashView
 from wifit3.ui.screens.scanner import ScannerView
@@ -62,12 +62,12 @@ def test_app_resets_invalid_saved_theme(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text("theme = 'missing-theme'\n", encoding="utf-8")
     monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
-    Config.theme = "textual-dark"
+    Config.theme = DEFAULT_THEME
 
     app = WifiteApp()
 
-    assert app.theme == "textual-dark"
-    assert Config.theme == "textual-dark"
-    assert "theme = 'textual-dark'" in config_path.read_text(encoding="utf-8")
+    assert app.theme == DEFAULT_THEME
+    assert Config.theme == DEFAULT_THEME
+    assert f"theme = '{DEFAULT_THEME}'" in config_path.read_text(encoding="utf-8")
 
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -1,9 +1,12 @@
 import pytest
 
+from wifit3.persist.config import Config
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.screens.splash import SplashView
 from wifit3.ui.screens.scanner import ScannerView
 from textual.widgets import RichLog, DataTable
+
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("no_usb_devices")  # ui/conftest.py
@@ -37,4 +40,33 @@ async def test_app_layout_and_boot():
         
         # Check that FocusViewV2 is registered (but requires target_ap to mount properly without escaping immediately, so we won't push it here)
         assert "focus" in pilot.app._installed_screens
+
+
+@pytest.mark.usefixtures("no_usb_devices")
+def test_app_refreshes_theme_art_when_theme_changes(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
+    Config.theme = "textual-dark"
+    app = WifiteApp()
+    refreshed = []
+    monkeypatch.setattr(app, "_refresh_theme_dependents", lambda: refreshed.append(True))
+
+    app.watch_theme("textual-light")
+
+    assert refreshed == [True]
+    assert Config.theme == "textual-light"
+
+
+@pytest.mark.usefixtures("no_usb_devices")
+def test_app_resets_invalid_saved_theme(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("theme = 'missing-theme'\n", encoding="utf-8")
+    monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
+    Config.theme = "textual-dark"
+
+    app = WifiteApp()
+
+    assert app.theme == "textual-dark"
+    assert Config.theme == "textual-dark"
+    assert "theme = 'textual-dark'" in config_path.read_text(encoding="utf-8")
 

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wifit3.persist.config import Config
+from wifit3.persist.config import DEFAULT_THEME, Config
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.screens.splash import SplashView
 from wifit3.ui.screens.scanner import ScannerView
@@ -46,7 +46,7 @@ async def test_app_layout_and_boot():
 def test_app_refreshes_theme_art_when_theme_changes(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
-    Config.theme = "textual-dark"
+    Config.theme = DEFAULT_THEME
     app = WifiteApp()
     refreshed = []
     monkeypatch.setattr(app, "_refresh_theme_dependents", lambda: refreshed.append(True))
@@ -62,11 +62,11 @@ def test_app_resets_invalid_saved_theme(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text("theme = 'missing-theme'\n", encoding="utf-8")
     monkeypatch.setattr("wifit3.persist.config._PATH", config_path)
-    Config.theme = "textual-dark"
+    Config.theme = DEFAULT_THEME
 
     app = WifiteApp()
 
-    assert app.theme == "textual-dark"
-    assert Config.theme == "textual-dark"
-    assert "theme = 'textual-dark'" in config_path.read_text(encoding="utf-8")
+    assert app.theme == DEFAULT_THEME
+    assert Config.theme == DEFAULT_THEME
+    assert f"theme = '{DEFAULT_THEME}'" in config_path.read_text(encoding="utf-8")
 

--- a/tests/ui/test_themes.py
+++ b/tests/ui/test_themes.py
@@ -8,9 +8,11 @@ from textual.widgets import Static
 from wifit3.ui.ansi_art import recolor_logo
 from wifit3.ui.app import WifiteApp
 from wifit3.ui.themes import (
+    BLACKLISTED_THEME_NAMES,
     BUILTIN_THEMES_DIR,
     ThemeFilePoller,
     ThemeLoadError,
+    is_theme_blacklisted,
     load_theme_file,
     register_app_themes,
 )
@@ -19,13 +21,24 @@ from wifit3.ui.themes import (
 class _ThemeApp:
     def __init__(self):
         self.themes = {}
+        self.available_themes = self.themes
 
     def register_theme(self, theme):
         self.themes[theme.name] = theme
 
 
+def test_register_app_themes_keeps_textual_themes_available():
+    app = WifiteApp()
+
+    assert BLACKLISTED_THEME_NAMES == []
+    assert not is_theme_blacklisted("textual-dark")
+    assert "wifit3-green-dark" in app.available_themes
+    assert "textual-dark" in app.available_themes
+    assert "textual-light" in app.available_themes
+
+
 def test_builtin_green_theme_defines_selection_colors():
-    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green-dark.toml")
+    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green.toml")
 
     assert theme.variables["block-cursor-background"] == "#00ff88"
     assert theme.variables["block-hover-background"] == "#163322"
@@ -240,5 +253,5 @@ name = "live-theme"
     result = poller.reload_if_changed(app)
 
     assert result.changed is True
-    assert result.registered == ("wifit3-green-dark", "live-theme")
+    assert result.registered == ("wifit3-green", "live-theme")
     assert app.themes["live-theme"].primary == "#00ff88"

--- a/tests/ui/test_themes.py
+++ b/tests/ui/test_themes.py
@@ -25,7 +25,7 @@ class _ThemeApp:
 
 
 def test_builtin_green_theme_defines_selection_colors():
-    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green.toml")
+    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green-dark.toml")
 
     assert theme.variables["block-cursor-background"] == "#00ff88"
     assert theme.variables["block-hover-background"] == "#163322"
@@ -240,5 +240,5 @@ name = "live-theme"
     result = poller.reload_if_changed(app)
 
     assert result.changed is True
-    assert result.registered == ("wifit3-green", "live-theme")
+    assert result.registered == ("wifit3-green-dark", "live-theme")
     assert app.themes["live-theme"].primary == "#00ff88"

--- a/tests/ui/test_themes.py
+++ b/tests/ui/test_themes.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+from textual.theme import Theme
+from textual.widgets import Static
+
+from wifit3.ui.ansi_art import recolor_logo
+from wifit3.ui.app import WifiteApp
+from wifit3.ui.themes import (
+    BUILTIN_THEMES_DIR,
+    ThemeFilePoller,
+    ThemeLoadError,
+    load_theme_file,
+    register_app_themes,
+)
+
+
+class _ThemeApp:
+    def __init__(self):
+        self.themes = {}
+
+    def register_theme(self, theme):
+        self.themes[theme.name] = theme
+
+
+def test_builtin_green_theme_defines_selection_colors():
+    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green.toml")
+
+    assert theme.variables["block-cursor-background"] == "#00ff88"
+    assert theme.variables["block-hover-background"] == "#163322"
+    assert theme.variables["screen-selection-background"] == "#007a48"
+
+
+def test_theme_file_loads_logo_variables(tmp_path: Path):
+    path = tmp_path / "theme.toml"
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "test-theme"
+dark = true
+
+[colors]
+primary = "#112233"
+
+[variables]
+logo_color_primary = "#445566"
+logo_color_secondary = "#778899"
+logo_text_primary = "#aabbcc"
+logo_text_secondary = "#ddeeff"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    theme = load_theme_file(path)
+
+    assert theme.name == "test-theme"
+    assert theme.variables == {
+        "logo_color_primary": "#445566",
+        "logo_color_secondary": "#778899",
+        "logo_text_primary": "#aabbcc",
+        "logo_text_secondary": "#ddeeff",
+    }
+
+
+def test_theme_file_normalizes_compact_hex_colors(tmp_path: Path):
+    path = tmp_path / "theme.toml"
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "compact-theme"
+
+[colors]
+primary = "#0f"
+secondary = "#abc"
+accent = "#abcd"
+error = "#11223344"
+
+[variables]
+logo_color_primary = "#7"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    theme = load_theme_file(path)
+
+    assert theme.primary == "#0f0f0f"
+    assert theme.secondary == "#aabbcc"
+    assert theme.accent == "#aabbcc"
+    assert theme.error == "#112233"
+    assert theme.variables["logo_color_primary"] == "#777777"
+
+
+def test_theme_file_rejects_invalid_logo_variable_color(tmp_path: Path):
+    path = tmp_path / "theme.toml"
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "bad-theme"
+
+[variables]
+logo_color_primary = "not-a-color"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ThemeLoadError, match="variables.logo_color_primary"):
+        load_theme_file(path)
+
+
+def test_recolor_logo_maps_baked_ansi_palette():
+    text = Text("abcd")
+    text.stylize("#ffffff on #00ff00", 0, 1)
+    text.stylize("#ffffff on #008000", 1, 2)
+    text.stylize("#808080", 2, 3)
+    text.stylize("#123456 on #654321", 3, 4)
+
+    recolored = recolor_logo(text, {
+        "logo_color_primary": "#010203",
+        "logo_color_secondary": "#040506",
+        "logo_text_primary": "#070809",
+        "logo_text_secondary": "#0a0b0c",
+    })
+
+    styles = [span.style for span in recolored.spans]
+    assert str(styles[0]) == "#070809 on #010203"
+    assert str(styles[1]) == "#070809 on #040506"
+    assert str(styles[2]) == "#0a0b0c"
+    assert str(styles[3]) == "#123456 on #654321"
+
+
+def test_recolor_logo_uses_dark_defaults_when_variable_is_missing():
+    text = Text("x")
+    text.stylize("#ffffff on #00ff00", 0, 1)
+
+    recolored = recolor_logo(text, {"logo_text_primary": "#111111"})
+
+    assert str(recolored.spans[0].style) == "#111111 on #00ff00"
+
+
+def test_recolor_logo_uses_light_defaults_for_textual_light_theme():
+    text = Text("x")
+    text.stylize("#ffffff on #00ff00", 0, 1)
+
+    recolored = recolor_logo(text, {}, dark=False)
+
+    assert str(recolored.spans[0].style) == "#111111 on #00bb00"
+
+
+@pytest.mark.usefixtures("no_usb_devices")
+async def test_splash_logo_uses_current_theme_variables():
+    app = WifiteApp()
+    app.register_theme(Theme(
+        name="logo-test", primary="#ffffff",
+        variables={"logo_color_primary": "#010203", "logo_text_primary": "#040506"},
+    ))
+    app.theme = "logo-test"
+
+    async with app.run_test() as pilot:
+        logo = pilot.app.screen.query_one("#ascii-art", Static).content
+
+    styles = {str(span.style) for span in logo.spans}
+
+    assert any("#010203" in style for style in styles)
+    assert any("#040506" in style for style in styles)
+
+
+def test_register_app_themes_reloads_changed_user_theme(tmp_path: Path):
+    path = tmp_path / "live.toml"
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "live-theme"
+
+[colors]
+primary = "#111111"
+""".strip(),
+        encoding="utf-8",
+    )
+    app = _ThemeApp()
+    register_app_themes(app, user_dir=tmp_path)
+
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "live-theme"
+
+[colors]
+primary = "#222222"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = register_app_themes(app, user_dir=tmp_path)
+
+    assert result.changed is True
+    assert "live-theme" in result.registered
+    assert app.themes["live-theme"].primary == "#222222"
+
+
+def test_register_app_themes_skips_invalid_user_theme(tmp_path: Path):
+    path = tmp_path / "live.toml"
+    path.write_text("not toml =", encoding="utf-8")
+    app = _ThemeApp()
+
+    result = register_app_themes(app, user_dir=tmp_path)
+
+    assert result.changed is True
+    assert result.skipped == ("live.toml",)
+
+
+def test_theme_file_poller_reloads_only_after_theme_file_changes(tmp_path: Path):
+    app = _ThemeApp()
+    poller = ThemeFilePoller(user_dir=tmp_path)
+    poller.start()
+
+    assert poller.reload_if_changed(app).changed is False
+
+    path = tmp_path / "live.toml"
+    path.write_text(
+        """
+schema = 1
+
+[theme]
+name = "live-theme"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = poller.reload_if_changed(app)
+
+    assert result.changed is True
+    assert result.registered == ("wifit3-green", "live-theme")
+    assert app.themes["live-theme"].primary == "#00ff88"

--- a/tests/ui/test_themes.py
+++ b/tests/ui/test_themes.py
@@ -38,7 +38,7 @@ def test_register_app_themes_keeps_textual_themes_available():
 
 
 def test_builtin_green_theme_defines_selection_colors():
-    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green.toml")
+    theme = load_theme_file(BUILTIN_THEMES_DIR / "wifit3-green-dark.toml")
 
     assert theme.variables["block-cursor-background"] == "#00ff88"
     assert theme.variables["block-hover-background"] == "#163322"
@@ -253,5 +253,5 @@ name = "live-theme"
     result = poller.reload_if_changed(app)
 
     assert result.changed is True
-    assert result.registered == ("wifit3-green", "live-theme")
+    assert result.registered == ("wifit3-green-dark", "live-theme")
     assert app.themes["live-theme"].primary == "#00ff88"


### PR DESCRIPTION
Added custom color theme wifit3-green-dark
Added way to create custom themes for users and devs [vis docs](https://github.com/xxcosita3czxx/wifit3/blob/theming/docs/THEMES.md)
Added way to theme the logo itself
Added "--theme-reload" for faster theme making
Added docs for theming.
Added default light logo theme
Changed default theme to wifit3-green-dark
Added a way to blacklist theme from loading (for future use)


The logo theming has a limitation of having only 4 colors editable. Its due to editing the color table itself than creating a new ansi logo. Easier to make and better for the space.