### PR TITLE
fix(ar9271): track physical device across firmware boot

### DIFF
--- a/src/wifit3/chips/ar9271_v2/driver.py
+++ b/src/wifit3/chips/ar9271_v2/driver.py
@@ -17,10 +17,11 @@ import asyncio
 import logging
 import struct
 import time
-from typing import Callable, ClassVar, List, Optional
+from typing import Callable, ClassVar, List, Optional, Tuple
 
 import libusb_package
 import usb.core
+from usb.core import Device
 import usb.util
 
 from wifit3.chips.rx_reader import RxReaderThread
@@ -69,7 +70,7 @@ class AR9271V2Driver(Driver):
     LINUX_REPLUG_AFTER_MODPROBE: ClassVar[bool] = True   # replug, not the fragile FW-download self-cold
     FAKE_MAC: ClassVar[FakeMacSupport] = FakeMacSupport.SPOOFABLE
 
-    def __init__(self, dev: usb.core.Device):
+    def __init__(self, dev: Device):
         super().__init__()          # base owns the ACK tally (_ack_detect_on / _our_tx_macs / _ack_counts)
         self.transport = AR9271Transport(dev)
         self.is_warm = False
@@ -82,7 +83,7 @@ class AR9271V2Driver(Driver):
         self._reader: Optional[RxReaderThread] = None
 
     @classmethod
-    def from_usb_device(cls, dev: usb.core.Device, id_entry: DeviceID) -> "AR9271V2Driver":
+    def from_usb_device(cls, dev: Device, id_entry: DeviceID) -> "AR9271V2Driver":
         drv = cls(dev)
         drv.product_name = id_entry.product_name   # SUPPORTED_IDS label; _adopt narrows by OUI
         return drv
@@ -233,13 +234,11 @@ class AR9271V2Driver(Driver):
                     "few seconds, replug, and try again.") from e
 
         cold_dev = self.transport.dev
-        cold_ports = tuple(getattr(cold_dev, "port_numbers", None) or ())
-        allow_unlocated_fallback = False
+        cold_ports = self._get_port_numbers(cold_dev)
+        unique_vidpid = False
         if not cold_ports:
-            backend = libusb_package.get_libusb1_backend()
-            matches = usb.core.find(find_all=True, idVendor=C.AR9271_VID,
-                                    idProduct=C.AR9271_PID, backend=backend)
-            allow_unlocated_fallback = len(list(matches or ())) == 1
+            unique_vidpid = len(self._find_matching_ar9271_devices(cold_dev)) == 1
+
         _p(0.10, "Downloading AR9271 firmware...")
         await loop.run_in_executor(None, firmware.download, self.transport, fw)
         try:
@@ -248,8 +247,7 @@ class AR9271V2Driver(Driver):
             pass
 
         _p(0.30, "Waiting for AR9271 to re-enumerate...")
-        redev = await self._await_reenumeration(
-            cold_dev, allow_unlocated_fallback=allow_unlocated_fallback)
+        redev = await self._await_reenumeration(cold_dev, unique_vidpid=unique_vidpid)
         if redev is None:
             raise BringUpError(
                 "re-enumeration",
@@ -281,37 +279,36 @@ class AR9271V2Driver(Driver):
         except Exception:  # noqa: BLE001
             pass
 
-    async def _await_reenumeration(
-            self, original: usb.core.Device, *, allow_unlocated_fallback: bool = False,
-    ) -> Optional[usb.core.Device]:
-        """Reacquire this physical card, not an identical sibling.
+    def _get_port_numbers(self, dev: Device) -> Tuple[int, ...]:
+        """Hub port numbers from root to ``dev``, via PyUSB's non-public ``port_numbers``."""
+        return tuple(getattr(dev, "port_numbers", None) or ())
 
-        AR9271 firmware boot may change the USB device address.  ``port_numbers`` is the stable
-        physical route through that boot; VID:PID is not sufficient when two AR9271 cards are
-        attached.  Linux may retain the address across this firmware boot.  If the backend has no
-        topology, an unchanged address is safe; an address change is safe only when this was the
-        sole matching card before boot.
-        """
+    def _find_matching_ar9271_devices(self, dev: Device) -> List[Device]:
+        vid = getattr(dev, "idVendor", C.AR9271_VID)
+        pid = getattr(dev, "idProduct", C.AR9271_PID)
         backend = libusb_package.get_libusb1_backend()
-        original_bus = getattr(original, "bus", None)
-        original_address = getattr(original, "address", None)
-        original_ports = tuple(getattr(original, "port_numbers", None) or ())
+        found = usb.core.find(find_all=True, backend=backend,
+                              idVendor=vid, idProduct=pid)
+        return list(found or ())
+
+    async def _await_reenumeration(self, original: Device, *, unique_vidpid: bool = False) -> Optional[Device]:
+        """Reacquire this device, not an identical sibling.
+        ``unique_vidpid`` is true if no other attached devices share this VID:PID."""
+        og_bus = original.bus
+        og_addr = original.address
+        og_ports = self._get_port_numbers(original)
         for _ in range(12):                 # ~3 s; the chip boots its text image and re-attaches
             await asyncio.sleep(0.25)
-            found = usb.core.find(find_all=True, idVendor=C.AR9271_VID,
-                                  idProduct=C.AR9271_PID, backend=backend)
-            matches = list(found or ())
-            for dev in matches:
-                if original_ports:
-                    if (getattr(dev, "bus", None) != original_bus
-                            or tuple(getattr(dev, "port_numbers", None) or ()) != original_ports):
-                        continue
-                elif (getattr(dev, "bus", None), getattr(dev, "address", None)) != (
-                        original_bus, original_address):
-                    continue
+            matching_devs = self._find_matching_ar9271_devices(original)
+            for dev in matching_devs:
+                if og_ports:
+                    if dev.bus != og_bus or self._get_port_numbers(dev) != og_ports:
+                        continue  # Plugged in to a different bus/port, ignore.
+                elif (dev.bus, dev.address) != (og_bus, og_addr):
+                    continue  # Not the same bus/address, ignore.
                 return dev
-            if not original_ports and allow_unlocated_fallback and len(matches) == 1:
-                return matches[0]
+            if not og_ports and unique_vidpid and len(matching_devs) == 1:
+                return matching_devs[0]  # Single device for this VID:PID
         return None
 
     def _is_chip_warm(self) -> bool:
@@ -355,7 +352,7 @@ class AR9271V2Driver(Driver):
             except Exception as e:                 # noqa: BLE001 — best-effort toggle resync
                 logger.debug("ar9271_v2: clear_halt(0x%02x) skipped: %s", ep, e)
 
-    def _claim(self, dev: usb.core.Device) -> None:
+    def _claim(self, dev: Device) -> None:
         """Configure + claim interface 0 on the (re-enumerated, firmware-booted) device. The
         bulk/interrupt pipes the bring-up + RX use need the interface claimed (EP0 control — the
         firmware download — does not, which is why that succeeds first). Right after re-enumeration

--- a/src/wifit3/chips/ar9271_v2/driver.py
+++ b/src/wifit3/chips/ar9271_v2/driver.py
@@ -193,7 +193,7 @@ class AR9271V2Driver(Driver):
             logger.warning("ar9271_v2: post-boot handshake mis-framed (first bytes %s); "
                            "tearing down for one clean retry", e.raw[:8].hex(" "))
             await self._teardown_cold_attempt()
-            redev = await self._await_reenumeration()
+            redev = await self._await_reenumeration(self.transport.dev)
             if redev is not None:
                 self.transport = AR9271Transport(redev)
             try:
@@ -233,6 +233,13 @@ class AR9271V2Driver(Driver):
                     "few seconds, replug, and try again.") from e
 
         cold_dev = self.transport.dev
+        cold_ports = tuple(getattr(cold_dev, "port_numbers", None) or ())
+        allow_unlocated_fallback = False
+        if not cold_ports:
+            backend = libusb_package.get_libusb1_backend()
+            matches = usb.core.find(find_all=True, idVendor=C.AR9271_VID,
+                                    idProduct=C.AR9271_PID, backend=backend)
+            allow_unlocated_fallback = len(list(matches or ())) == 1
         _p(0.10, "Downloading AR9271 firmware...")
         await loop.run_in_executor(None, firmware.download, self.transport, fw)
         try:
@@ -241,7 +248,8 @@ class AR9271V2Driver(Driver):
             pass
 
         _p(0.30, "Waiting for AR9271 to re-enumerate...")
-        redev = await self._await_reenumeration()
+        redev = await self._await_reenumeration(
+            cold_dev, allow_unlocated_fallback=allow_unlocated_fallback)
         if redev is None:
             raise BringUpError(
                 "re-enumeration",
@@ -273,13 +281,37 @@ class AR9271V2Driver(Driver):
         except Exception:  # noqa: BLE001
             pass
 
-    async def _await_reenumeration(self) -> Optional[usb.core.Device]:
+    async def _await_reenumeration(
+            self, original: usb.core.Device, *, allow_unlocated_fallback: bool = False,
+    ) -> Optional[usb.core.Device]:
+        """Reacquire this physical card, not an identical sibling.
+
+        AR9271 firmware boot may change the USB device address.  ``port_numbers`` is the stable
+        physical route through that boot; VID:PID is not sufficient when two AR9271 cards are
+        attached.  Linux may retain the address across this firmware boot.  If the backend has no
+        topology, an unchanged address is safe; an address change is safe only when this was the
+        sole matching card before boot.
+        """
         backend = libusb_package.get_libusb1_backend()
+        original_bus = getattr(original, "bus", None)
+        original_address = getattr(original, "address", None)
+        original_ports = tuple(getattr(original, "port_numbers", None) or ())
         for _ in range(12):                 # ~3 s; the chip boots its text image and re-attaches
             await asyncio.sleep(0.25)
-            dev = usb.core.find(idVendor=C.AR9271_VID, idProduct=C.AR9271_PID, backend=backend)
-            if dev is not None:
+            found = usb.core.find(find_all=True, idVendor=C.AR9271_VID,
+                                  idProduct=C.AR9271_PID, backend=backend)
+            matches = list(found or ())
+            for dev in matches:
+                if original_ports:
+                    if (getattr(dev, "bus", None) != original_bus
+                            or tuple(getattr(dev, "port_numbers", None) or ()) != original_ports):
+                        continue
+                elif (getattr(dev, "bus", None), getattr(dev, "address", None)) != (
+                        original_bus, original_address):
+                    continue
                 return dev
+            if not original_ports and allow_unlocated_fallback and len(matches) == 1:
+                return matches[0]
         return None
 
     def _is_chip_warm(self) -> bool:

--- a/src/wifit3/chips/ar9271_v2/transport.py
+++ b/src/wifit3/chips/ar9271_v2/transport.py
@@ -9,11 +9,13 @@ interrupt pipes (HTC/WMI + RX/TX) land with M2.
 """
 from __future__ import annotations
 
+import usb
+
 from . import constants as C
 
 
 class AR9271Transport:
-    def __init__(self, dev):
+    def __init__(self, dev: usb.core.Device):
         self.dev = dev
 
     def control_out(self, bRequest: int, wValue: int, data: bytes | None) -> int:

--- a/tests/chips/ar9271_v2/test_reenumeration.py
+++ b/tests/chips/ar9271_v2/test_reenumeration.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from wifit3.chips.ar9271_v2.driver import AR9271V2Driver
+
+
+@pytest.mark.asyncio
+async def test_reenumeration_selects_same_physical_port_with_identical_sibling():
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(6,))
+    sibling = SimpleNamespace(bus=1, address=6, port_numbers=(1,))
+    rebooted = SimpleNamespace(bus=1, address=8, port_numbers=(6,))
+    driver = AR9271V2Driver(original)
+
+    with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
+          patch("wifit3.chips.ar9271_v2.driver.usb.core.find",
+                return_value=[sibling, rebooted])):
+        found = await driver._await_reenumeration(original)
+
+    assert found is rebooted
+
+
+@pytest.mark.asyncio
+async def test_reenumeration_allows_linux_to_retain_address():
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(6,))
+    driver = AR9271V2Driver(original)
+
+    with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
+          patch("wifit3.chips.ar9271_v2.driver.usb.core.find", return_value=[original])):
+        found = await driver._await_reenumeration(original)
+
+    assert found is original
+
+
+@pytest.mark.asyncio
+async def test_reenumeration_without_topology_keeps_same_address():
+    original = SimpleNamespace(bus=1, address=7, port_numbers=None)
+    sibling = SimpleNamespace(bus=1, address=6, port_numbers=None)
+    driver = AR9271V2Driver(original)
+
+    with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
+          patch("wifit3.chips.ar9271_v2.driver.usb.core.find",
+                return_value=[sibling, original])):
+        found = await driver._await_reenumeration(original)
+
+    assert found is original
+
+
+@pytest.mark.asyncio
+async def test_reenumeration_without_topology_never_selects_sibling():
+    original = SimpleNamespace(bus=1, address=7, port_numbers=None)
+    sibling = SimpleNamespace(bus=1, address=6, port_numbers=None)
+    driver = AR9271V2Driver(original)
+
+    with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
+          patch("wifit3.chips.ar9271_v2.driver.usb.core.find", return_value=[sibling])):
+        found = await driver._await_reenumeration(original)
+
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_reenumeration_without_topology_allows_known_single_card_address_change():
+    original = SimpleNamespace(bus=1, address=7, port_numbers=None)
+    rebooted = SimpleNamespace(bus=1, address=8, port_numbers=None)
+    driver = AR9271V2Driver(original)
+
+    with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
+          patch("wifit3.chips.ar9271_v2.driver.usb.core.find", return_value=[rebooted])):
+        found = await driver._await_reenumeration(original, allow_unlocated_fallback=True)
+
+    assert found is rebooted

--- a/tests/chips/ar9271_v2/test_reenumeration.py
+++ b/tests/chips/ar9271_v2/test_reenumeration.py
@@ -34,7 +34,7 @@ async def test_reenumeration_allows_linux_to_retain_address():
 
 
 @pytest.mark.asyncio
-async def test_reenumeration_without_topology_keeps_same_address():
+async def test_reenumeration_without_ports_keeps_same_address():
     original = SimpleNamespace(bus=1, address=7, port_numbers=None)
     sibling = SimpleNamespace(bus=1, address=6, port_numbers=None)
     driver = AR9271V2Driver(original)
@@ -48,7 +48,7 @@ async def test_reenumeration_without_topology_keeps_same_address():
 
 
 @pytest.mark.asyncio
-async def test_reenumeration_without_topology_never_selects_sibling():
+async def test_reenumeration_without_ports_never_selects_sibling():
     original = SimpleNamespace(bus=1, address=7, port_numbers=None)
     sibling = SimpleNamespace(bus=1, address=6, port_numbers=None)
     driver = AR9271V2Driver(original)
@@ -61,13 +61,13 @@ async def test_reenumeration_without_topology_never_selects_sibling():
 
 
 @pytest.mark.asyncio
-async def test_reenumeration_without_topology_allows_known_single_card_address_change():
+async def test_reenumeration_without_ports_allows_known_single_card_address_change():
     original = SimpleNamespace(bus=1, address=7, port_numbers=None)
     rebooted = SimpleNamespace(bus=1, address=8, port_numbers=None)
     driver = AR9271V2Driver(original)
 
     with (patch("wifit3.chips.ar9271_v2.driver.asyncio.sleep"),
           patch("wifit3.chips.ar9271_v2.driver.usb.core.find", return_value=[rebooted])):
-        found = await driver._await_reenumeration(original, allow_unlocated_fallback=True)
+        found = await driver._await_reenumeration(original, unique_vidpid=True)
 
     assert found is rebooted


### PR DESCRIPTION
## What changed

Track an AR9271 by its physical USB topology `(bus, port_numbers)` while
reacquiring it after firmware boot.

When topology information is unavailable, the fallback is deliberately
conservative:

- An unchanged bus/address may be reused.
- An address change is accepted only when the card was the sole matching
  AR9271 before firmware boot.
- An ambiguous identical sibling is never selected.

Regression tests cover identical adapters, retained and changed USB addresses,
and backends without topology information.

## Why

The previous re-enumeration path searched only by VID/PID. With two identical
`0cf3:9271` adapters connected, it could return the already-running first card
while initializing the second. The second bring-up would then repeatedly try
to claim an interface already owned by the first card.

The root-to-device USB port path remains tied to the physical connector across
firmware boot, allowing identical adapters to be distinguished without relying
on their non-unique USB serial strings.

## Verification

Hardware-tested on Linux with two AR9271 adapters connected simultaneously:

- Reproduced the second-card bring-up failure.
- Verified one warm reattach and one cold firmware bring-up after selecting by
  physical USB path.
- Repeated two-card warm reattachment after adding the conservative
  no-topology fallback.
- Both adapters completed bring-up and were closed cleanly.

Automated checks:

- `uv run pytest`: 2,110 passed, 15 deselected
- `uv run pytest -q tests/chips/ar9271_v2`: 106 passed
- `uv run ruff check src/ tests/`
- `git diff --check`

The offline pcap gate was not rerun because its capture bundle is not included
in this checkout. This change affects host-side USB device selection only and
does not alter firmware download, register operations, or wire sequencing.

AR9271 reference:
[`src/wifit3/chips/ar9271_v2/AR9271_V2.md`](https://github.com/derv82/wifit3/blob/master/src/wifit3/chips/ar9271_v2/AR9271_V2.md)
