### PR TITLE
feat(release): build macOS as universal2 (Intel x86_64 + Apple Silicon)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@
 #   2. `release` waits for all builds, DOWNLOADS every artifact, and attaches them to a
 #      GitHub Release for the pushed tag (softprops/action-gh-release).
 #
-# PyInstaller does not cross-compile, hence one job per target OS. macOS runners are free for
-# public repos, so the Apple Silicon (arm64) binary is built too. Intel macOS runners are being
-# retired by GitHub, so they are skipped. See wifit3.spec.
+# PyInstaller does not cross-compile, hence one job per target OS. macOS ships as a single
+# universal2 binary (Intel x86_64 + Apple Silicon arm64) built on an arm64 runner — see the
+# build-macos job. Building universal2 on arm64 also survives GitHub's Aug-2027 retirement of
+# its last Intel runner (macos-15-intel). macOS runners are free for public repos.
 #
 # Trigger: push a version tag, e.g.  git tag v0.1.0 && git push origin v0.1.0
 # Dry run: the "Run workflow" button (workflow_dispatch) builds + uploads artifacts you can
@@ -41,9 +42,7 @@ jobs:
           - os: ubuntu-22.04          # build on older glibc so the binary runs on more distros
             artifact_name: wifit3-linux-x64
             build_path: dist/wifit3
-          - os: macos-14              # Apple Silicon (arm64)
-            artifact_name: wifit3-macos-arm64
-            build_path: dist/wifit3
+          # macOS is NOT in this matrix: it needs a universal2 toolchain (see build-macos).
 
     steps:
       - uses: actions/checkout@v7
@@ -103,9 +102,101 @@ jobs:
           path: out/${{ matrix.artifact_name }}
           if-no-files-found: error
 
+  # macOS universal2 (one fat binary: Intel x86_64 + Apple Silicon arm64). Built on an arm64
+  # runner, so this survives GitHub's Aug-2027 retirement of Intel runners (macos-15-intel).
+  # universal2 needs a FAT interpreter and fat bundled binaries — see the inline comments.
+  build-macos:
+    name: Build (macos universal2)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same tag/version gate as the build matrix job.
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          proj=$(grep -m1 '^__version__ = ' src/wifit3/__init__.py | sed -E 's/.*"(.*)".*/\1/')
+          echo "tag=$tag  __version__=$proj"
+          if [ "$tag" != "$proj" ]; then
+            echo "::error::Tag v$tag does not match src/wifit3/__init__.py __version__ $proj"
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      # uv-managed and setup-python CPython builds are THIN (single-arch); only the python.org
+      # installer ships universal2. Pin 3.12.10 — the last 3.12.x with a macOS installer (later
+      # 3.12.x are source-only security releases). Matches the matrix jobs' python-version "3.12".
+      - name: Install universal2 CPython (python.org)
+        run: |
+          curl -fsSL -o /tmp/python.pkg https://www.python.org/ftp/python/3.12.10/python-3.12.10-macos11.pkg
+          sudo installer -pkg /tmp/python.pkg -target /
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -c \
+            "import sysconfig; p = sysconfig.get_platform(); assert 'universal2' in p, p; print('universal2 python OK:', p)"
+
+      - name: Sync env (runtime + dev deps, incl. PyInstaller) against the universal2 interpreter
+        run: uv sync --group dev --python /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
+
+      # libusb_package ships only THIN macOS wheels (separate x86_64/arm64), and PyInstaller's
+      # strict arch validation aborts a universal2 build on any non-fat binary. lipo the two thin
+      # dylibs into one fat dylib and swap it into the venv before building. Verified locally:
+      # the fattened dylib still loads via libusb_package.get_library_path() and passes --smoke.
+      - name: Fatten the bundled libusb dylib (universal2)
+        shell: bash
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          ver=$(uv run --no-sync python -c "from importlib.metadata import version; print(version('libusb-package'))")
+          echo "fattening libusb-package $ver"
+          for plat in macosx_10_9_x86_64 macosx_11_0_arm64; do
+            url=$(curl -fsSL "https://pypi.org/pypi/libusb-package/$ver/json" | python3 -c \
+              "import json,sys; print(next(u['url'] for u in json.load(sys.stdin)['urls'] if '$plat' in u['filename']))")
+            curl -fsSL -o "$work/$plat.whl" "$url"
+            unzip -qo "$work/$plat.whl" -d "$work/$plat"
+          done
+          x64lib=$(find "$work/macosx_10_9_x86_64" -name 'libusb-1.0*' -type f)
+          armlib=$(find "$work/macosx_11_0_arm64" -name 'libusb-1.0*' -type f)
+          target=$(find .venv -name 'libusb-1.0*' -path '*libusb_package*' -type f)
+          lipo -create "$x64lib" "$armlib" -output "$work/libusb-fat.dylib"
+          codesign --sign - --force "$work/libusb-fat.dylib"  # re-ad-hoc-sign: arm64 requires a valid sig
+          cp "$work/libusb-fat.dylib" "$target"
+          lipo -archs "$target" | grep -qw x86_64 && lipo -archs "$target" | grep -qw arm64
+
+      - name: Build onefile binary (universal2)
+        run: uv run --no-sync pyinstaller wifit3.spec --noconfirm --clean
+
+      # Boot the bundle on BOTH slices: arm64 natively, x86_64 under Rosetta (installed on demand;
+      # available on GitHub's arm64 runners). Catches a thin-sliced lib or dropped data file per-arch.
+      - name: Smoke-test the bundle (arm64 native + x86_64 Rosetta)
+        shell: bash
+        run: |
+          set -euo pipefail
+          lipo -archs dist/wifit3
+          lipo -archs dist/wifit3 | grep -qw x86_64 && lipo -archs dist/wifit3 | grep -qw arm64
+          dist/wifit3 --version
+          dist/wifit3 --smoke
+          sudo softwareupdate --install-rosetta --agree-to-license
+          arch -x86_64 dist/wifit3 --smoke
+          echo "universal2 bundle smoke OK"
+
+      - name: Stage artifact
+        run: |
+          mkdir -p out
+          cp dist/wifit3 out/wifit3-macos-universal2
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wifit3-macos-universal2
+          path: out/wifit3-macos-universal2
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
-    needs: build
+    needs: [build, build-macos]
     # Only publish for an actual tag push; a manual workflow_dispatch just leaves the
     # artifacts attached to the run for download.
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@
 #      GitHub Release for the pushed tag (softprops/action-gh-release).
 #
 # PyInstaller does not cross-compile, hence one job per target OS. macOS ships as a single
-# universal2 binary (Intel x86_64 + Apple Silicon arm64) built on an arm64 runner — see the
-# build-macos job. Building universal2 on arm64 also survives GitHub's Aug-2027 retirement of
-# its last Intel runner (macos-15-intel). macOS runners are free for public repos.
+# universal2 binary (Intel x86_64 + Apple Silicon arm64) built on an arm64 runner.
 #
 # Trigger: push a version tag, e.g.  git tag v0.1.0 && git push origin v0.1.0
 # Dry run: the "Run workflow" button (workflow_dispatch) builds + uploads artifacts you can
@@ -42,7 +40,7 @@ jobs:
           - os: ubuntu-22.04          # build on older glibc so the binary runs on more distros
             artifact_name: wifit3-linux-x64
             build_path: dist/wifit3
-          # macOS is NOT in this matrix: it needs a universal2 toolchain (see build-macos).
+          # macOS: see build-macos
 
     steps:
       - uses: actions/checkout@v7
@@ -102,9 +100,7 @@ jobs:
           path: out/${{ matrix.artifact_name }}
           if-no-files-found: error
 
-  # macOS universal2 (one fat binary: Intel x86_64 + Apple Silicon arm64). Built on an arm64
-  # runner, so this survives GitHub's Aug-2027 retirement of Intel runners (macos-15-intel).
-  # universal2 needs a FAT interpreter and fat bundled binaries — see the inline comments.
+  # macOS universal2 (one fat binary: Intel x86_64 + Apple Silicon arm64). Built on an arm64 runner.
   build-macos:
     name: Build (macos universal2)
     runs-on: macos-latest
@@ -127,9 +123,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      # uv-managed and setup-python CPython builds are THIN (single-arch); only the python.org
-      # installer ships universal2. Pin 3.12.10 — the last 3.12.x with a macOS installer (later
-      # 3.12.x are source-only security releases). Matches the matrix jobs' python-version "3.12".
+      # The python.org installer ships universal2, pinned to 3.12.10 (the last 3.12.x with a macOS installer)
       - name: Install universal2 CPython (python.org)
         run: |
           curl -fsSL -o /tmp/python.pkg https://www.python.org/ftp/python/3.12.10/python-3.12.10-macos11.pkg
@@ -137,14 +131,11 @@ jobs:
           /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -c \
             "import sysconfig; p = sysconfig.get_platform(); assert 'universal2' in p, p; print('universal2 python OK:', p)"
 
-      - name: Sync env (runtime + dev deps, incl. PyInstaller) against the universal2 interpreter
+      - name: Sync uv env
         run: uv sync --group dev --python /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
 
-      # libusb_package ships only THIN macOS wheels (separate x86_64/arm64), and PyInstaller's
-      # strict arch validation aborts a universal2 build on any non-fat binary. lipo the two thin
-      # dylibs into one fat dylib and swap it into the venv before building. Verified locally:
-      # the fattened dylib still loads via libusb_package.get_library_path() and passes --smoke.
-      - name: Fatten the bundled libusb dylib (universal2)
+      # lipo libusb's thin wheels (x86_64/arm64) into one fat dylib and swap it into the venv before building.
+      - name: Download libusb, lipo a fat dylib (universal2)
         shell: bash
         run: |
           set -euo pipefail
@@ -163,7 +154,8 @@ jobs:
           lipo -create "$x64lib" "$armlib" -output "$work/libusb-fat.dylib"
           codesign --sign - --force "$work/libusb-fat.dylib"  # re-ad-hoc-sign: arm64 requires a valid sig
           cp "$work/libusb-fat.dylib" "$target"
-          lipo -archs "$target" | grep -qw x86_64 && lipo -archs "$target" | grep -qw arm64
+          lipo_output=$(lipo -archs "$target")
+          grep -qw x86_64 <<<"$lipo_output" && grep -qw arm64 <<<"$lipo_output"
 
       - name: Build onefile binary (universal2)
         run: uv run --no-sync pyinstaller wifit3.spec --noconfirm --clean
@@ -174,8 +166,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          lipo -archs dist/wifit3
-          lipo -archs dist/wifit3 | grep -qw x86_64 && lipo -archs dist/wifit3 | grep -qw arm64
+          lipo_output=$(lipo -archs dist/wifit3)
+          grep -qw x86_64 <<<"$lipo_output" && grep -qw arm64 <<<"$lipo_output"
           dist/wifit3 --version
           dist/wifit3 --smoke
           sudo softwareupdate --install-rosetta --agree-to-license

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Grab a prebuilt binary from the [**Releases**](https://github.com/derv82/wifit3/
 
 - **Windows** — download `wifit3-windows-x64.exe` and run it.
 - **Linux** — download `wifit3-linux-x64`, then `chmod +x wifit3-linux-x64 && ./wifit3-linux-x64`.
-- **macOS (Apple Silicon):** download `wifit3-macos-arm64`, then clear the download quarantine and run it:
-  `xattr -d com.apple.quarantine wifit3-macos-arm64 && chmod +x wifit3-macos-arm64 && ./wifit3-macos-arm64`
+- **macOS (Apple Silicon + Intel):** download `wifit3-macos-universal2`, then clear the download quarantine and run it:
+  `xattr -d com.apple.quarantine wifit3-macos-universal2 && chmod +x wifit3-macos-universal2 && ./wifit3-macos-universal2`
 
 ### Run from source
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Grab a prebuilt binary from the [**Releases**](https://github.com/derv82/wifit3/
 
 - **Windows** — download `wifit3-windows-x64.exe` and run it.
 - **Linux** — download `wifit3-linux-x64`, then `chmod +x wifit3-linux-x64 && ./wifit3-linux-x64`.
-- **macOS (Apple Silicon + Intel):** download `wifit3-macos-universal2`, then clear the download quarantine and run it:
-  `xattr -d com.apple.quarantine wifit3-macos-universal2 && chmod +x wifit3-macos-universal2 && ./wifit3-macos-universal2`
+- **macOS (Apple Silicon + Intel):**
+  1. Download `wifit3-macos-universal2`
+  2. Bypass quarantine: `xattr -d com.apple.quarantine wifit3-macos-universal2 && chmod +x wifit3-macos-universal2`
+  3. Run it: `./wifit3-macos-universal2`
 
 ### Run from source
 
@@ -101,7 +103,7 @@ uv run wifit3
 
 ### Build
 
-Build using `uv run pyinstaller wifit3.spec --noconfirm --clean` (Windows: `dist/wifit3.exe`, Linux: `dist/wifit3`).
+Build using `uv run pyinstaller wifit3.spec --noconfirm --clean` (Windows: `dist/wifit3.exe`, Linux/OSX: `dist/wifit3`).
 
 ### First-run setup
 

--- a/wifit3.spec
+++ b/wifit3.spec
@@ -64,7 +64,10 @@ a = Analysis(
     runtime_hooks=[],
     # pyshark shells out to a separate Wireshark/tshark install (can't be bundled) and is
     # dev/RE-only; the rest are dev tooling that has no place in a distributed build.
-    excludes=["pyshark", "pytest", "ruff", "textual_dev"],
+    # PIL: pillow is a dev-only dep (asset generation in scripts/); nothing in src/ imports it,
+    # yet it leaks into the analysis graph and its thin .so aborts the universal2 build
+    # (IncompatibleBinaryArchError). Excluding it also shrinks the Windows/Linux binaries.
+    excludes=["pyshark", "pytest", "ruff", "textual_dev", "PIL"],
     noarchive=False,
 )
 pyz = PYZ(a.pure)

--- a/wifit3.spec
+++ b/wifit3.spec
@@ -1,10 +1,7 @@
 # PyInstaller build spec for wifit3 — build with: uv run pyinstaller wifit3.spec
 #
 # Produces a single self-contained onefile binary — dist/wifit3.exe on Windows, dist/wifit3 on
-# Linux/macOS. PyInstaller does NOT cross-compile: build each target ON that OS. The macOS build
-# (release.yml's build-macos job) targets universal2 (Intel + Apple Silicon in one binary); that
-# requires a universal2 CPython (python.org installer — uv/setup-python pythons are thin) and every
-# bundled binary to be fat, so the workflow lipo-fattens the thin libusb dylib before building.
+# Linux/macOS. PyInstaller does NOT cross-compile: build each target on that OS.
 #
 # onefile (active) vs onedir tradeoff:
 #   onefile: one binary; unpacks into a temp dir on each launch (slower cold start), trips AV/SmartScreen more.
@@ -64,9 +61,6 @@ a = Analysis(
     runtime_hooks=[],
     # pyshark shells out to a separate Wireshark/tshark install (can't be bundled) and is
     # dev/RE-only; the rest are dev tooling that has no place in a distributed build.
-    # PIL: pillow is a dev-only dep (asset generation in scripts/); nothing in src/ imports it,
-    # yet it leaks into the analysis graph and its thin .so aborts the universal2 build
-    # (IncompatibleBinaryArchError). Excluding it also shrinks the Windows/Linux binaries.
     excludes=["pyshark", "pytest", "ruff", "textual_dev", "PIL"],
     noarchive=False,
 )

--- a/wifit3.spec
+++ b/wifit3.spec
@@ -1,7 +1,10 @@
 # PyInstaller build spec for wifit3 — build with: uv run pyinstaller wifit3.spec
 #
 # Produces a single self-contained onefile binary — dist/wifit3.exe on Windows, dist/wifit3 on
-# Linux. PyInstaller does NOT cross-compile: build each target ON that OS. macOS is not a build target.
+# Linux/macOS. PyInstaller does NOT cross-compile: build each target ON that OS. The macOS build
+# (release.yml's build-macos job) targets universal2 (Intel + Apple Silicon in one binary); that
+# requires a universal2 CPython (python.org installer — uv/setup-python pythons are thin) and every
+# bundled binary to be fat, so the workflow lipo-fattens the thin libusb dylib before building.
 #
 # onefile (active) vs onedir tradeoff:
 #   onefile: one binary; unpacks into a temp dir on each launch (slower cold start), trips AV/SmartScreen more.
@@ -86,6 +89,9 @@ exe = EXE(
     upx=False,
     console=True,
     icon=_icon,
+    # universal2 (fat Intel+arm64) on macOS; thin elsewhere. Strict arch validation will abort
+    # the build if any bundled binary isn't fat — that's the desired loud failure.
+    target_arch="universal2" if sys.platform == "darwin" else None,
     runtime_tmpdir=None,
 )
 


### PR DESCRIPTION
Follow-up to the request in [#26 (comment)](https://github.com/derv82/wifit3/pull/26#issuecomment-5412450236):

> _Can we support this for the Intel Mac's by building this as a macos universal until github gets rid of it all together?_

Yes — this PR replaces the arm64-only macOS build with a single **universal2** binary (`wifit3-macos-universal2`) that runs natively on both Intel (x86_64) and Apple Silicon (arm64) Macs.

## How it works

New `build-macos` job in `release.yml` (replacing the `macos-14` matrix row). It builds on an **arm64 runner**, so Intel support survives GitHub's retirement of its last Intel runner ([`macos-15-intel` goes away Aug 2027](https://github.com/actions/runner-images/issues/13045)) — no Intel runner is needed at any point.

universal2 requires a fat interpreter and fat bundled binaries, so the job:

1. Installs the python.org universal2 CPython 3.12.10 (uv-managed / setup-python CPython builds are thin per-arch; 3.12.10 is the last 3.12.x with a macOS installer).
2. `uv sync`s the project env against that interpreter.
3. lipo-fattens the bundled libusb dylib: `libusb_package` ships thin-only macOS wheels (separate x86_64/arm64), and PyInstaller's strict arch validation aborts a universal2 build on any non-fat binary. The job downloads both thin wheels from PyPI, merges the dylibs with `lipo`, ad-hoc re-signs, and swaps the fat one into the venv.
4. Builds with `target_arch="universal2"` in `wifit3.spec` (thin on other OSes, unchanged).
5. Smoke-tests **both slices**: arm64 natively, x86_64 under Rosetta (`arch -x86_64 dist/wifit3 --smoke`).

## Also fixes

`PIL` is added to the spec's `excludes`: pillow (a dev-only dep, used by `scripts/` asset generation) leaked into PyInstaller's analysis graph and its thin-arm64 `_imagingft.so` aborts universal2 validation. Nothing in `src/` imports PIL; excluding it also stops bundling it into the Windows/Linux binaries.

## Verification

Dry-run (`workflow_dispatch`) on my fork with this exact workflow: all builds green — https://github.com/jantian3n/wifit3/actions/runs/32931726318

The produced `wifit3-macos-universal2` was downloaded and verified: `lipo -archs` reports `x86_64 arm64`, and `--smoke` passes both natively (arm64) and under Rosetta (x86_64).

Note: the binary remains unsigned/unnotarized; the README download section documents the `xattr -d com.apple.quarantine` workaround.