### PR TITLE
Packages building

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -1,0 +1,158 @@
+# Experimental manual-only macOS app/DMG packaging.
+# This does not publish a Release; it uploads a drag-to-Applications DMG for local testing.
+
+name: macOS App DMG
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: macos-app-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-app:
+    name: Build experimental macOS app
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      # The python.org installer ships universal2, pinned to 3.12.10 (the last 3.12.x with a macOS installer).
+      - name: Install universal2 CPython (python.org)
+        run: |
+          curl -fsSL -o /tmp/python.pkg https://www.python.org/ftp/python/3.12.10/python-3.12.10-macos11.pkg
+          sudo installer -pkg /tmp/python.pkg -target /
+          /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -c \
+            "import sysconfig; p = sysconfig.get_platform(); assert 'universal2' in p, p; print('universal2 python OK:', p)"
+
+      - name: Sync uv env
+        run: uv sync --group dev --python /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
+
+      - name: Download libusb, lipo a fat dylib (universal2)
+        shell: bash
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          ver=$(uv run --no-sync python -c "from importlib.metadata import version; print(version('libusb-package'))")
+          echo "fattening libusb-package $ver"
+          for plat in macosx_10_9_x86_64 macosx_11_0_arm64; do
+            url=$(curl -fsSL "https://pypi.org/pypi/libusb-package/$ver/json" | python3 -c \
+              "import json,sys; print(next(u['url'] for u in json.load(sys.stdin)['urls'] if '$plat' in u['filename']))")
+            curl -fsSL -o "$work/$plat.whl" "$url"
+            unzip -qo "$work/$plat.whl" -d "$work/$plat"
+          done
+          x64lib=$(find "$work/macosx_10_9_x86_64" -name 'libusb-1.0*' -type f)
+          armlib=$(find "$work/macosx_11_0_arm64" -name 'libusb-1.0*' -type f)
+          target=$(find .venv -name 'libusb-1.0*' -path '*libusb_package*' -type f)
+          lipo -create "$x64lib" "$armlib" -output "$work/libusb-fat.dylib"
+          codesign --sign - --force "$work/libusb-fat.dylib"
+          cp "$work/libusb-fat.dylib" "$target"
+          lipo_output=$(lipo -archs "$target")
+          grep -qw x86_64 <<<"$lipo_output" && grep -qw arm64 <<<"$lipo_output"
+
+      - name: Build onefile binary (universal2)
+        run: uv run --no-sync pyinstaller wifit3.spec --noconfirm --clean
+
+      - name: Smoke-test the bundle (arm64 native + x86_64 Rosetta)
+        shell: bash
+        run: |
+          set -euo pipefail
+          lipo_output=$(lipo -archs dist/wifit3)
+          grep -qw x86_64 <<<"$lipo_output" && grep -qw arm64 <<<"$lipo_output"
+          dist/wifit3 --version
+          dist/wifit3 --smoke
+          sudo softwareupdate --install-rosetta --agree-to-license
+          arch -x86_64 dist/wifit3 --smoke
+          echo "universal2 bundle smoke OK"
+
+      - name: Build .app bundle
+        id: build_app
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          app="out/Wifit3.app"
+          rm -rf out
+          mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+          cp dist/wifit3 "$app/Contents/Resources/wifit3"
+          chmod +x "$app/Contents/Resources/wifit3"
+
+          cat > "$app/Contents/Info.plist" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleDevelopmentRegion</key>
+            <string>en</string>
+            <key>CFBundleExecutable</key>
+            <string>Wifit3</string>
+            <key>CFBundleIdentifier</key>
+            <string>dev.derv82.wifit3</string>
+            <key>CFBundleName</key>
+            <string>Wifit3</string>
+            <key>CFBundleDisplayName</key>
+            <string>Wifit3</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>CFBundleShortVersionString</key>
+            <string>$version</string>
+            <key>CFBundleVersion</key>
+            <string>${GITHUB_RUN_NUMBER}</string>
+            <key>LSMinimumSystemVersion</key>
+            <string>11.0</string>
+          </dict>
+          </plist>
+          EOF
+
+          cat > "$app/Contents/MacOS/Wifit3" <<'EOF'
+          #!/bin/bash
+          set -euo pipefail
+          app_dir="$(cd "$(dirname "$0")/.." && pwd)"
+          bin="$app_dir/Resources/wifit3"
+          osascript <<APPLESCRIPT
+          tell application "Terminal"
+            activate
+            do script quoted form of "$bin"
+          end tell
+          APPLESCRIPT
+          EOF
+          chmod +x "$app/Contents/MacOS/Wifit3"
+
+          codesign --sign - --force --deep "$app"
+          plutil -lint "$app/Contents/Info.plist"
+          echo "app_path=$app" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build drag-to-Applications DMG
+        id: build_dmg
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_name="wifit3-macos-universal2-${{ steps.build_app.outputs.version }}.dmg"
+          rm -rf dmgroot
+          mkdir -p dmgroot
+          ditto "${{ steps.build_app.outputs.app_path }}" "dmgroot/Wifit3.app"
+          ln -s /Applications dmgroot/Applications
+          hdiutil create \
+            -volname "Wifit3" \
+            -srcfolder dmgroot \
+            -ov \
+            -format UDZO \
+            "out/$dmg_name"
+          hdiutil verify "out/$dmg_name"
+          echo "dmg_name=$dmg_name" >> "$GITHUB_OUTPUT"
+          echo "dmg_path=out/$dmg_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.build_dmg.outputs.dmg_name }}
+          path: ${{ steps.build_dmg.outputs.dmg_path }}
+          if-no-files-found: error

--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -116,12 +116,13 @@ jobs:
           set -euo pipefail
           app_dir="$(cd "$(dirname "$0")/.." && pwd)"
           bin="$app_dir/Resources/wifit3"
-          osascript <<APPLESCRIPT
-          tell application "Terminal"
-            activate
-            do script quoted form of "$bin"
-          end tell
-          APPLESCRIPT
+          cmd="$(mktemp "${TMPDIR:-/tmp}/wifit3.XXXXXX.command")"
+          cat > "$cmd" <<RUN
+          #!/bin/bash
+          exec "$bin"
+          RUN
+          chmod +x "$cmd"
+          open "$cmd"
           EOF
           chmod +x "$app/Contents/MacOS/Wifit3"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          version="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
           binary="dist/wifit3-linux-x64"
           chmod +x "$binary"
           mkdir -p out
@@ -234,7 +238,7 @@ jobs:
           Maintainer: derv82
           Homepage: https://github.com/derv82/wifit3
           Description: Wifite but USB-only & cross-platform.
-          An Userland 802.11 auditing tool. GPL-2.0
+           An userland 802.11 auditing tool. GPL-2.0
           EOF
 
           dpkg-deb --build --root-owner-group "$debroot" "out/wifit3_${version}_amd64.deb"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,9 +287,11 @@ jobs:
           }
           EOF
 
-          (cd "$archbuild" && makepkg --noconfirm --cleanbuild --nodeps)
-          mv "$archbuild/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst" out/
-          tar --list -f "out/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst"
+          (cd "$archbuild" && PKGEXT='.pkg.tar.zst' makepkg --noconfirm --cleanbuild --nodeps)
+          archpkg=$(find "$archbuild" -maxdepth 1 -name "${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.*" -print -quit)
+          test -n "$archpkg"
+          mv "$archpkg" out/
+          tar --list -f "out/$(basename "$archpkg")"
 
       - name: Upload Linux packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,9 +186,95 @@ jobs:
           path: out/wifit3-macos-universal2
           if-no-files-found: error
 
+  package-linux:
+    name: Package Linux redistributables
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download Linux binary
+        uses: actions/download-artifact@v8
+        with:
+          name: wifit3-linux-x64
+          path: dist
+
+      - name: Install packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd
+
+      - name: Package .deb and Arch package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          binary="dist/wifit3-linux-x64"
+          chmod +x "$binary"
+          mkdir -p out
+
+          # Debian / Ubuntu package.
+          debroot="pkg/deb"
+          rm -rf "$debroot"
+          install -Dm755 "$binary" "$debroot/usr/bin/wifit3-linux-x64"
+          ln -s wifit3-linux-x64 "$debroot/usr/bin/wifit3"
+          mkdir -p "$debroot/DEBIAN"
+
+          cat > "$debroot/DEBIAN/control" <<EOF
+          Package: wifit3
+          Version: $version
+          Section: net
+          Priority: optional
+          Architecture: amd64
+          Maintainer: derv82
+          Homepage: https://github.com/derv82/wifit3
+          Description: Wifite but USB-only & cross-platform.
+          An Userland 802.11 auditing tool. GPL-2.0
+          EOF
+
+          dpkg-deb --build --root-owner-group "$debroot" "out/wifit3_${version}_amd64.deb"
+          dpkg-deb --info "out/wifit3_${version}_amd64.deb"
+          dpkg-deb --contents "out/wifit3_${version}_amd64.deb"
+
+          # Arch Linux package. This wraps the prebuilt binary, so use the -bin package name.
+          pkgname="wifit3-bin"
+          pkgver="${version//-/_}"
+          pkgrel="1"
+          archbuild="pkg/arch-build"
+          rm -rf "$archbuild"
+          mkdir -p "$archbuild"
+          cp "$binary" "$archbuild/wifit3-linux-x64"
+          cat > "$archbuild/PKGBUILD" <<EOF
+          pkgname=$pkgname
+          pkgver=$pkgver
+          pkgrel=$pkgrel
+          pkgdesc='Wifite but USB-only & cross-platform.'
+          arch=('x86_64')
+          url='https://github.com/derv82/wifit3'
+          license=('GPL-2.0')
+          depends=('glibc')
+          source=('wifit3-linux-x64')
+          sha256sums=('SKIP')
+
+          package() {
+            install -Dm755 "\$srcdir/wifit3-linux-x64" "\$pkgdir/usr/bin/wifit3-linux-x64"
+            ln -s wifit3-linux-x64 "\$pkgdir/usr/bin/wifit3"
+          }
+          EOF
+
+          (cd "$archbuild" && makepkg --noconfirm --cleanbuild)
+          mv "$archbuild/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst" out/
+          tar --list -f "out/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst"
+
+      - name: Upload Linux packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-packages
+          path: out/*
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
-    needs: [build, build-macos]
+    needs: [build, build-macos, package-linux]
     # Only publish for an actual tag push; a manual workflow_dispatch just leaves the
     # artifacts attached to the run for download.
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,9 @@ jobs:
   package-linux:
     name: Package Linux redistributables
     needs: build
-    runs-on: ubuntu-22.04
+    # Packaging only: the binary still comes from the ubuntu-22.04 build artifact above.
+    # ubuntu-24.04 has Debian's Arch makepkg/pacman tooling available via apt.
+    runs-on: ubuntu-24.04
     steps:
       - name: Download Linux binary
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
           sudo chmod -R a+rwx /var/lib/pacman
 
       - name: Package .deb (Debian / Ubuntu)
+        id: package_deb
         shell: bash
         run: |
           set -euo pipefail
@@ -243,11 +244,23 @@ jobs:
            An userland 802.11 auditing tool. GPL-2.0
           EOF
 
-          dpkg-deb --build --root-owner-group "$debroot" "out/wifit3_${version}_amd64.deb"
-          dpkg-deb --info "out/wifit3_${version}_amd64.deb"
-          dpkg-deb --contents "out/wifit3_${version}_amd64.deb"
+          deb_path="out/wifit3_${version}_amd64.deb"
+          dpkg-deb --build --root-owner-group "$debroot" "$deb_path"
+          dpkg-deb --info "$deb_path"
+          dpkg-deb --contents "$deb_path"
+          echo "deb_name=$(basename "$deb_path")" >> "$GITHUB_OUTPUT"
+          echo "deb_path=$deb_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.package_deb.outputs.deb_name }}
+          path: ${{ steps.package_deb.outputs.deb_path }}
+          if-no-files-found: error
 
       - name: Package .pkg.tar.zst (arch linux)
+        id: package_arch
+        shell: bash
         run: |
           set -euo pipefail
 
@@ -274,6 +287,7 @@ jobs:
           pkgver=$pkgver
           pkgrel=$pkgrel
           pkgdesc='Wifite but USB-only & cross-platform.'
+          packager='Github Actions'
           arch=('x86_64')
           url='https://github.com/derv82/wifit3'
           license=('GPL-2.0')
@@ -290,14 +304,17 @@ jobs:
           (cd "$archbuild" && PKGEXT='.pkg.tar.zst' makepkg --noconfirm --cleanbuild --nodeps)
           archpkg=$(find "$archbuild" -maxdepth 1 -name "${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.*" -print -quit)
           test -n "$archpkg"
-          mv "$archpkg" out/
-          tar --list -f "out/$(basename "$archpkg")"
+          arch_path="out/$(basename "$archpkg")"
+          mv "$archpkg" "$arch_path"
+          tar --list -f "$arch_path"
+          echo "arch_name=$(basename "$arch_path")" >> "$GITHUB_OUTPUT"
+          echo "arch_path=$arch_path" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Linux packages
+      - name: Upload Arch package
         uses: actions/upload-artifact@v7
         with:
-          name: linux-packages
-          path: out/*
+          name: ${{ steps.package_arch.outputs.arch_name }}
+          path: ${{ steps.package_arch.outputs.arch_path }}
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,9 +206,11 @@ jobs:
           sudo add-apt-repository -y universe
           sudo apt-get update
           apt-cache policy pacman-package-manager
-          sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd
+          sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd libarchive-tools
+          sudo mkdir -p /var/lib/pacman/local
+          sudo chmod -R a+rwx /var/lib/pacman
 
-      - name: Package .deb and Arch package
+      - name: Package .deb (Debian / Ubuntu)
         shell: bash
         run: |
           set -euo pipefail
@@ -245,6 +247,8 @@ jobs:
           dpkg-deb --info "out/wifit3_${version}_amd64.deb"
           dpkg-deb --contents "out/wifit3_${version}_amd64.deb"
 
+      - name: Package .pkg.tar.zst (arch linux)
+        run: |
           # Arch Linux package. This wraps the prebuilt binary, so use the -bin package name.
           pkgname="wifit3-bin"
           pkgver="${version//-/_}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,10 +205,27 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y universe
           sudo apt-get update
-          apt-cache policy pacman-package-manager
           sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd libarchive-tools
           sudo mkdir -p /var/lib/pacman/local
           sudo chmod -R a+rwx /var/lib/pacman
+
+      - name: Resolve package metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          {
+            echo "PACKAGE_VERSION=$version"
+            echo "ARCH_PKGVER=${version//-/_}"
+            echo "PACKAGE_REL=1"
+            echo "PACKAGE_DESC=Wifite but USB-only & cross-platform."
+            echo "PACKAGE_URL=https://github.com/derv82/wifit3"
+            echo "PACKAGE_LICENSE=GPL-2.0"
+          } >> "$GITHUB_ENV"
 
       - name: Package .deb (Debian / Ubuntu)
         id: package_deb
@@ -216,11 +233,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version="0.0.0.${GITHUB_RUN_NUMBER}"
-          fi
+          version="$PACKAGE_VERSION"
           binary="dist/wifit3-linux-x64"
           chmod +x "$binary"
           mkdir -p out
@@ -239,9 +252,9 @@ jobs:
           Priority: optional
           Architecture: amd64
           Maintainer: derv82
-          Homepage: https://github.com/derv82/wifit3
-          Description: Wifite but USB-only & cross-platform.
-           An userland 802.11 auditing tool. GPL-2.0
+          Homepage: $PACKAGE_URL
+          Description: $PACKAGE_DESC
+           An userland 802.11 auditing tool. $PACKAGE_LICENSE
           EOF
 
           deb_path="out/wifit3_${version}_amd64.deb"
@@ -260,24 +273,18 @@ jobs:
 
       - name: Package .pkg.tar.zst (arch linux)
         id: package_arch
-        shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version="0.0.0.${GITHUB_RUN_NUMBER}"
-          fi
-
+          version="$PACKAGE_VERSION"
           binary="dist/wifit3-linux-x64"
           chmod +x "$binary" # i know its redundant but just to be sure
           mkdir -p out
 
           # Arch Linux package. This wraps the prebuilt binary, so use the -bin package name.
           pkgname="wifit3-bin"
-          pkgver="${version//-/_}"
-          pkgrel="1"
+          pkgver="$ARCH_PKGVER"
+          pkgrel="$PACKAGE_REL"
           archbuild="pkg/arch-build"
           rm -rf "$archbuild"
           mkdir -p "$archbuild"
@@ -286,11 +293,11 @@ jobs:
           pkgname=$pkgname
           pkgver=$pkgver
           pkgrel=$pkgrel
-          pkgdesc='Wifite but USB-only & cross-platform.'
+          pkgdesc='$PACKAGE_DESC'
           packager='Github Actions'
           arch=('x86_64')
-          url='https://github.com/derv82/wifit3'
-          license=('GPL-2.0')
+          url='$PACKAGE_URL'
+          license=('$PACKAGE_LICENSE')
           depends=('glibc')
           source=('wifit3-linux-x64')
           sha256sums=('SKIP')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,8 +204,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y universe
+
           sudo apt-get update
           sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd libarchive-tools
+
           sudo mkdir -p /var/lib/pacman/local
           sudo chmod -R a+rwx /var/lib/pacman
 
@@ -213,6 +215,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
             version="${GITHUB_REF_NAME#v}"
           else
@@ -261,6 +264,7 @@ jobs:
           dpkg-deb --build --root-owner-group "$debroot" "$deb_path"
           dpkg-deb --info "$deb_path"
           dpkg-deb --contents "$deb_path"
+
           echo "deb_name=$(basename "$deb_path")" >> "$GITHUB_OUTPUT"
           echo "deb_path=$deb_path" >> "$GITHUB_OUTPUT"
 
@@ -309,11 +313,11 @@ jobs:
           EOF
 
           (cd "$archbuild" && PKGEXT='.pkg.tar.zst' makepkg --noconfirm --cleanbuild --nodeps)
-          archpkg=$(find "$archbuild" -maxdepth 1 -name "${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.*" -print -quit)
-          test -n "$archpkg"
+
+          archpkg="$archbuild/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst"
           arch_path="out/$(basename "$archpkg")"
           mv "$archpkg" "$arch_path"
-          tar --list -f "$arch_path"
+
           echo "arch_name=$(basename "$arch_path")" >> "$GITHUB_OUTPUT"
           echo "arch_path=$arch_path" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,10 @@ jobs:
       - name: Install packaging tools
         run: |
           sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+          apt-cache policy pacman-package-manager
           sudo apt-get install -y pacman-package-manager fakeroot binutils file zstd
 
       - name: Package .deb and Arch package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           }
           EOF
 
-          (cd "$archbuild" && makepkg --noconfirm --cleanbuild)
+          (cd "$archbuild" && makepkg --noconfirm --cleanbuild --nodeps)
           mv "$archbuild/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst" out/
           tar --list -f "out/${pkgname}-${pkgver}-${pkgrel}-x86_64.pkg.tar.zst"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,18 @@ jobs:
 
       - name: Package .pkg.tar.zst (arch linux)
         run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v[0-9]* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+
+          binary="dist/wifit3-linux-x64"
+          chmod +x "$binary" # i know its redundant but just to be sure
+          mkdir -p out
+
           # Arch Linux package. This wraps the prebuilt binary, so use the -bin package name.
           pkgname="wifit3-bin"
           pkgver="${version//-/_}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ __pycache__/
 .ruff_cache/
 .coverage
 htmlcov/
-build-dev.sh  # if you need this tool -> CONTRIBUTING.md has the exact command to be used instead :3
+# if you need this tool -> CONTRIBUTING.md has the exact command to be used instead :3
+build-dev.sh
 
 # PyInstaller build dir
 build/


### PR DESCRIPTION
Along side the normal artefact binaries, i also added creation of packages for arch linux and debian based devices. I think that would be good thing for the future when distributing packages to other repositories, and for now so people can update easier and use the system package manager for it.

What is implemented: Debian .deb, arch linux .pkg.tar.zst
What is to be implemented: MacOS DMG (does not install as binary tho - possibly automatic linkage on first run), Fedora/RHEL RPM