### PR TITLE
fix(ar9271): surface a clean replug error when the chip wedges mid-bringup

### DIFF
--- a/src/wifit3/chips/ar9271_v2/driver.py
+++ b/src/wifit3/chips/ar9271_v2/driver.py
@@ -202,6 +202,7 @@ class AR9271V2Driver(Driver):
             except Exception as e2:  # noqa: BLE001
                 await self._teardown_cold_attempt()
                 raise BringUpError(
+                    "post-boot handshake",
                     "AR9271 did not come up cleanly after firmware download (its control pipe "
                     "returned unexpected data twice). Unplug it, wait a few seconds, replug, and "
                     "try again.") from e2
@@ -230,6 +231,7 @@ class AR9271V2Driver(Driver):
                     await self._reader.stop()
                     self._reader = None
                 raise BringUpError(
+                    "warm reattach",
                     "AR9271 is warm and couldn't be re-attached to. Please unplug the card, wait a "
                     "few seconds, replug, and try again.") from e
 
@@ -240,7 +242,16 @@ class AR9271V2Driver(Driver):
             unique_vidpid = len(self._find_matching_ar9271_devices(cold_dev)) == 1
 
         _p(0.10, "Downloading AR9271 firmware...")
-        await loop.run_in_executor(None, firmware.download, self.transport, fw)
+        try:
+            await loop.run_in_executor(None, firmware.download, self.transport, fw)
+        except usb.core.USBError as e:
+            logger.warning("ar9271_v2: firmware download wedged (%s); falling back to replug", e)
+            raise BringUpError(
+                "firmware download",
+                "AR9271 stopped responding mid-firmware-upload (USB timeout). Its bootloader "
+                "state can't be reset in software once wedged this way -- please unplug the "
+                "card, wait a few seconds, replug, and try again.",
+            ) from e
         try:
             usb.util.dispose_resources(cold_dev)        # release the cold handle as it reboots
         except Exception:
@@ -262,7 +273,16 @@ class AR9271V2Driver(Driver):
         self._reader = RxReaderThread(loop, self._read_once, self._dispatch, name="ar9271v2-rx",
                                       on_fatal=lambda e: self._on_lost and self._on_lost(e))
         self._reader.start()
-        res = await loop.run_in_executor(None, bringup.cold_bringup, self.transport)
+        try:
+            res = await loop.run_in_executor(None, bringup.cold_bringup, self.transport)
+        except usb.core.USBError as e:
+            logger.warning("ar9271_v2: HTC/WMI init wedged (%s); falling back to replug", e)
+            await self._teardown_cold_attempt()
+            raise BringUpError(
+                "HTC/WMI init",
+                "AR9271 stopped responding during firmware init (USB timeout) -- please unplug "
+                "the card, wait a few seconds, replug, and try again.",
+            ) from e
         self._adopt(res)
         _p(1.0, f"AR9271 monitor up (ch 1, {self.mac_address})")
         return True
@@ -371,7 +391,7 @@ class AR9271V2Driver(Driver):
             except (usb.core.USBError, NotImplementedError) as e:
                 last = e
                 time.sleep(0.15)
-        raise BringUpError(f"AR9271 interface not claimable after re-enumeration: {last}")
+        raise BringUpError("claim", f"interface not claimable after re-enumeration: {last}")
 
     # ---- channel ----------------------------------------------------------
     async def set_channel(self, channel: int, scan: bool = False, *, _fastcc: bool = False) -> bool:

--- a/src/wifit3/chips/ar9271_v2/driver.py
+++ b/src/wifit3/chips/ar9271_v2/driver.py
@@ -203,9 +203,8 @@ class AR9271V2Driver(Driver):
                 await self._teardown_cold_attempt()
                 raise BringUpError(
                     "post-boot handshake",
-                    "AR9271 did not come up cleanly after firmware download (its control pipe "
-                    "returned unexpected data twice). Unplug it, wait a few seconds, replug, and "
-                    "try again.") from e2
+                    "failed after firmware download; please replug and try again."
+                ) from e2
 
     async def _bring_up_with_loop(self, loop, fw: bytes, _p) -> bool:
         """One full bring-up attempt under the app loop: warm-reattach if firmware is already
@@ -232,8 +231,8 @@ class AR9271V2Driver(Driver):
                     self._reader = None
                 raise BringUpError(
                     "warm reattach",
-                    "AR9271 is warm and couldn't be re-attached to. Please unplug the card, wait a "
-                    "few seconds, replug, and try again.") from e
+                    "failed on warm re-attach; please replug and try again."
+                ) from e
 
         cold_dev = self.transport.dev
         cold_ports = self._get_port_numbers(cold_dev)
@@ -248,9 +247,7 @@ class AR9271V2Driver(Driver):
             logger.warning("ar9271_v2: firmware download wedged (%s); falling back to replug", e)
             raise BringUpError(
                 "firmware download",
-                "AR9271 stopped responding mid-firmware-upload (USB timeout). Its bootloader "
-                "state can't be reset in software once wedged this way -- please unplug the "
-                "card, wait a few seconds, replug, and try again.",
+                "USB timeout; please replug and try again."
             ) from e
         try:
             usb.util.dispose_resources(cold_dev)        # release the cold handle as it reboots
@@ -280,8 +277,7 @@ class AR9271V2Driver(Driver):
             await self._teardown_cold_attempt()
             raise BringUpError(
                 "HTC/WMI init",
-                "AR9271 stopped responding during firmware init (USB timeout) -- please unplug "
-                "the card, wait a few seconds, replug, and try again.",
+                "USB timeout; please replug and try again."
             ) from e
         self._adopt(res)
         _p(1.0, f"AR9271 monitor up (ch 1, {self.mac_address})")

--- a/tests/chips/ar9271_v2/test_cold_bringup_wedge.py
+++ b/tests/chips/ar9271_v2/test_cold_bringup_wedge.py
@@ -1,0 +1,140 @@
+"""A wedged chip mid-cold-bringup (firmware download or the HTC/WMI init that follows) must
+surface a clean, actionable BringUpError -- not a raw usb.core.USBError traceback -- matching the
+replug-message pattern already used elsewhere in this driver (warm reattach, re-enumeration
+timeout, unsupported firmware version).
+
+Also covers every ``raise BringUpError(...)`` site in this file rendering correctly through
+``DeviceManager._fault_message`` (``f"{chip}: {stage} failed: {detail}"``): three sites used to
+pass their whole sentence as the single ``stage`` argument with no ``detail``, which rendered
+with "failed" nonsensically appended to the end of a complete sentence."""
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import usb.core
+
+from wifit3.chips.ar9271_v2.driver import AR9271V2Driver
+from wifit3.device.manager import DeviceManager
+from wifit3.errors import BringUpError
+
+
+def _renders_cleanly(e: BringUpError) -> bool:
+    """True if ``e`` has a short ``stage`` label + separate ``detail``, the shape
+    ``_fault_message`` needs -- not a whole sentence crammed into ``stage`` alone."""
+    msg = DeviceManager._fault_message(SimpleNamespace(chipset="AR9271 v2"), e)
+    return bool(e.detail) and not msg.rstrip().endswith("again. failed")
+
+
+async def _run_in_executor(_pool, fn, *args):
+    """Runs the "executor" work inline: every mocked call here is synchronous and side-effect
+    free (or raises via its own configured ``side_effect``), so no real thread pool is needed."""
+    return fn(*args)
+
+
+def _driver(mocker, original) -> tuple[AR9271V2Driver, MagicMock]:
+    driver = AR9271V2Driver(original)
+    mocker.patch.object(driver, "_is_chip_warm", return_value=False)
+    mocker.patch.object(driver, "_get_port_numbers", return_value=(1,))
+    mocker.patch.object(driver, "_find_matching_ar9271_devices", return_value=[original])
+    mocker.patch.object(driver, "_claim")
+    mocker.patch.object(driver, "_await_reenumeration",
+                        AsyncMock(return_value=SimpleNamespace(bus=1, address=8, port_numbers=(1,))))
+    mocker.patch("wifit3.chips.ar9271_v2.driver.usb.util.dispose_resources")
+    reader = MagicMock(start=MagicMock(), stop=AsyncMock())
+    mocker.patch("wifit3.chips.ar9271_v2.driver.RxReaderThread", return_value=reader)
+    return driver, reader
+
+
+@pytest.mark.asyncio
+async def test_firmware_download_timeout_becomes_a_clean_replug_error(mocker, caplog):
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(1,))
+    driver, reader = _driver(mocker, original)
+    mocker.patch("wifit3.chips.ar9271_v2.driver.firmware.download",
+                 side_effect=usb.core.USBError("Operation timed out"))
+    loop = mocker.MagicMock()
+    loop.run_in_executor = _run_in_executor
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(BringUpError) as exc_info:
+            await driver._bring_up_with_loop(loop, b"fw", lambda pct, msg: None)
+    assert exc_info.value.stage == "firmware download"
+    assert "replug" in str(exc_info.value).lower()
+    assert _renders_cleanly(exc_info.value)
+    reader.stop.assert_not_called()                    # never started: nothing to tear down
+    assert any("firmware download wedged" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cold_bringup_timeout_becomes_a_clean_replug_error_and_tears_down(mocker, caplog):
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(1,))
+    driver, reader = _driver(mocker, original)
+    mocker.patch("wifit3.chips.ar9271_v2.driver.firmware.download")
+    mocker.patch("wifit3.chips.ar9271_v2.driver.bringup.cold_bringup",
+                 side_effect=usb.core.USBError("Operation timed out"))
+    loop = mocker.MagicMock()
+    loop.run_in_executor = _run_in_executor
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(BringUpError) as exc_info:
+            await driver._bring_up_with_loop(loop, b"fw", lambda pct, msg: None)
+    assert exc_info.value.stage == "HTC/WMI init"
+    assert "replug" in str(exc_info.value).lower()
+    assert _renders_cleanly(exc_info.value)
+    reader.stop.assert_awaited_once()                  # torn down, not leaked
+    assert driver._reader is None
+    assert any("HTC/WMI init wedged" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_warm_reattach_failure_becomes_a_clean_replug_error(mocker, caplog):
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(1,))
+    driver, reader = _driver(mocker, original)
+    mocker.patch.object(driver, "_is_chip_warm", return_value=True)
+    mocker.patch.object(driver, "_clear_pipe_halts")
+    mocker.patch("wifit3.chips.ar9271_v2.driver.bringup.warm_reattach",
+                 side_effect=RuntimeError("WMI not responding"))
+    loop = mocker.MagicMock()
+    loop.run_in_executor = _run_in_executor
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(BringUpError) as exc_info:
+            await driver._bring_up_with_loop(loop, b"fw", lambda pct, msg: None)
+    assert exc_info.value.stage == "warm reattach"
+    assert _renders_cleanly(exc_info.value)
+    reader.stop.assert_awaited_once()                  # torn down, not leaked
+    assert any("warm reattach failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_post_boot_handshake_double_failure_becomes_a_clean_replug_error(mocker):
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(1,))
+    driver, _reader = _driver(mocker, original)
+    driver._reader = None
+    mocker.patch.object(driver, "_teardown_cold_attempt", AsyncMock())
+
+    from wifit3.chips.ar9271_v2 import htc
+
+    async def _always_mis_framed(*_a, **_k):
+        raise htc.HTCReadyError(b"\x00" * 8)
+
+    mocker.patch.object(driver, "_bring_up_with_loop", side_effect=_always_mis_framed)
+
+    with pytest.raises(BringUpError) as exc_info:
+        await driver.connect()
+    assert exc_info.value.stage == "post-boot handshake"
+    assert _renders_cleanly(exc_info.value)
+
+
+def test_claim_exhausted_retries_becomes_a_clean_replug_error(mocker):
+    mocker.patch("wifit3.chips.ar9271_v2.driver.time.sleep")     # skip the real ~6s of retries
+    mocker.patch("wifit3.chips.ar9271_v2.driver.usb.util.claim_interface",
+                 side_effect=usb.core.USBError("Access denied"))
+    original = SimpleNamespace(bus=1, address=7, port_numbers=(1,))
+    driver = AR9271V2Driver(original)
+    dev = SimpleNamespace(set_configuration=MagicMock())
+
+    with pytest.raises(BringUpError) as exc_info:
+        driver._claim(dev)
+    assert exc_info.value.stage == "claim"
+    assert _renders_cleanly(exc_info.value)

--- a/tests/chips/ar9271_v2/test_cold_bringup_wedge.py
+++ b/tests/chips/ar9271_v2/test_cold_bringup_wedge.py
@@ -1,12 +1,4 @@
-"""A wedged chip mid-cold-bringup (firmware download or the HTC/WMI init that follows) must
-surface a clean, actionable BringUpError -- not a raw usb.core.USBError traceback -- matching the
-replug-message pattern already used elsewhere in this driver (warm reattach, re-enumeration
-timeout, unsupported firmware version).
-
-Also covers every ``raise BringUpError(...)`` site in this file rendering correctly through
-``DeviceManager._fault_message`` (``f"{chip}: {stage} failed: {detail}"``): three sites used to
-pass their whole sentence as the single ``stage`` argument with no ``detail``, which rendered
-with "failed" nonsensically appended to the end of a complete sentence."""
+"""A wedged chip mid-cold-bringup must surface a clean, actionable BringUpError."""
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
## What changed

Every `BringUpError` this driver raises during bring-up now renders correctly through
`DeviceManager._fault_message` (`f"{chip}: {stage} failed: {detail}"`), and every USB-timeout
wedge case is now wrapped into one of these instead of leaking a raw exception.

- `firmware.download()` and `bringup.cold_bringup()` could previously raise a bare
  `usb.core.USBError` straight out of `connect()`. Both now catch it, log a warning, and raise a
  `BringUpError` with an actionable "unplug, wait, replug" message — matching how every other
  known failure mode in this driver already behaves (warm reattach, re-enumeration timeout,
  unsupported firmware version).
- Fixed the 3 existing call sites that passed their whole message as the single `stage` argument
  with no `detail`: warm-reattach failure, the post-boot-handshake double-failure, and `_claim`'s
  exhausted-retries case. `_fault_message` is built for the two-argument `(stage, detail)` shape;
  the single-argument form rendered with "failed" nonsensically appended to the end of a complete
  sentence, e.g. `"...try again. failed"`.

## Why

Killing wifit3 while it holds an AR9271 mid-connect can leave the chip's bootloader wedged such
that firmware download or the following HTC/WMI init times out — and no software recovery clears
it on this hardware. Confirmed live: `usb.core.Device.reset()` is a no-op for this chip (already
noted elsewhere in this driver), a sysfs `authorized` toggle didn't recover it either (the kernel
itself couldn't re-enumerate the port: `dmesg` showed `can't set config #1, error -110`), and
`uhubctl` found no power-switchable hub on the test machine. Only a real power-cycle fixes it, so
the driver should say that clearly instead of leaking a bare `USBTimeoutError` traceback — and
while fixing that message, found the sibling messages elsewhere in the same method had a real
rendering bug of their own.

## Verification

- `uv run pytest` — full suite passes (2115 passed)
- `uv run ruff check src/` — clean
- New unit tests (`tests/chips/ar9271_v2/test_cold_bringup_wedge.py`) inject a synthetic
  `usb.core.USBError` at both new wrap sites and assert a clean `BringUpError` (message, logging,
  and RX-reader teardown where relevant); separate tests exercise the three previously-malformed
  sites (warm reattach, post-boot handshake, `_claim`) and assert every one now renders through
  `_fault_message` without the "failed" artifact.
- Not re-tested against a genuinely wedged card live post-fix — this is a fix at the
  exception-handling/message layer, not the underlying hardware condition, so unit coverage is
  the right level here; the original discovery (and the ruled-out recovery attempts above) was
  live, on a real AR9271 wedged by an abrupt process kill.