### PR TITLE
feat: docs + support for T4U / T4U+ card.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A matching chipset does not guarantee that your wireless card will work.
 | Realtek RTL8821AU | 2.4 / 5 GHz | ALFA AWUS036**ACS**, TP-Link Archer T2U Plus/Nano |
 | Realtek RTL8821CU | 2.4 / 5 GHz | Auscoumer 600 Mbps |
 | Realtek RTL8922AU | 2.4 / 5 GHz | ASUS USB-BE93 |
-| Realtek RTL8822BU | 2.4 / 5 GHz | TP-Link T3U Plus |
+| Realtek RTL8822BU | 2.4 / 5 GHz | TP-Link T3U Plus, Archer T4U v3 / T4U+ |
 | Realtek RTL8822CU | 2.4 / 5 GHz | D-Link AC13U |
 | Realtek RTL8187L | 2.4 GHz | ALFA AWUS036**H** |
 | Realtek RTL8188EUS | 2.4 GHz | TP-Link TL-WN722N v2/v3 |

--- a/docs/SUPPORTED-HARDWARE.md
+++ b/docs/SUPPORTED-HARDWARE.md
@@ -194,8 +194,10 @@ live in each chip's `<CHIP>.md` (linked under its table).
 
 ### RTL8822BU
 <img align="right" width="90" height="165" src="../assets/cardart/card-archert3uplus.png" alt="TP-Link Archer T3U Plus">
+<img align="right" width="90" height="165" src="../assets/cardart/card-archert4uplus.png" alt="TP-Link Archer T4U Plus">
 
-*TP-Link Archer T3U Plus v1 · 2.4 / 5 GHz*
+
+*TP-Link Archer T3U Plus v1 / Archer T4U v3 / T4U+ · 2.4 / 5 GHz*
 
 > **Default = vendor/DKMS port** (table below). `WIFIT3_RTL8822=mainline` opts back.
 

--- a/docs/planning/BUGS.md
+++ b/docs/planning/BUGS.md
@@ -4,6 +4,29 @@ Tracked defects and design debt. Each entry is a **problem statement**, not a pr
 solution. The fix is whatever's simplest, tackled one at a time. Where a simple direction is
 obvious it's noted in one line; the point is to *remove* leaky abstractions, never add layers.
 
+## (CANTFIX) RTL8822BU TP-Link Archer T4U v3 / T4U+ ambiguity
+
+**Problem.** TP-Link manufactured multiple different models that all share
+the same exact device metadata.  A USB device with VID:PID `2357:0115` could be
+Archer T4U v3, v3.2, or Archer T4U+. All other descriptors appear to be identical.
+
+Known T4U+ sample (identical to T4U "v3.6" sample):
+- `idVendor:idProduct`: `2357:0115`
+- `manufacturer`: `Realtek`
+- `product`: `802.11ac NIC`
+- `serial`: `123456`
+- `bcdDevice`: `0210`
+- `bcdUSB/version`: `2.10`
+- `speed`: `480`
+- `chipset`: `RTL8822BU` (could be RTL8812BU given online reports)
+
+Links:
+- [linux-hardware.org@`2357:0115`](https://linux-hardware.org/?id=usb:2357-0115) (RTL8822BU, RTL8812BU)
+- [Wi-Cat.ru@T4Uv3.2](https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3.2) *("probably rtl8812bu")*
+  - [Wi-Cat.ru `2357:0115` disambiguation](https://shorturl.at/5iTC7)
+
+**Direction.** Keep dumping device info from other models; spot the diff.
+
 ## Expand EFUSE support
 
 Most drivers were ported against the single device they were tested on, so EFUSE derived values

--- a/src/wifit3/chips/products.py
+++ b/src/wifit3/chips/products.py
@@ -374,9 +374,10 @@ class TPLink(ProductName):
     ARCHER_T4UH_V2   = "Archer T4UH v2"  # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4UH
     ARCHER_T4UHP     = "Archer T4UHP"    # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4UHP
     ARCHER_T4UHP_V2  = "Archer T4UHP v2" # https://linux-hardware.org/?id=usb:2357-0122
-    ARCHER_T4U_PLUS  = "Archer T4U Plus" # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_Plus
+    ARCHER_T4U_PLUS  = "Archer T4U+"     # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_Plus
     ARCHER_T4U_V2    = "Archer T4U v2"   # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v2
-    ARCHER_T4U_V3    = "Archer T4U V3"   # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
+    ARCHER_T4U_V3    = "Archer T4U v3"   # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
+    ARCHER_T4U_V3_PLUS = "Archer T4U v3 / T4U+" # shared 2357:0115 label
     ARCHER_T9UH      = "Archer T9UH"     # https://wikidevi.wi-cat.ru/TP-LINK_Archer_T9UH
     ARCHER_TX20U_PLUS = "Archer TX20U+"  # https://wikidevi.wi-cat.ru/TP-LINK_Archer_TX35U_Plus (diff page) says: TP-LINK Archer TX20U Plus (AX1800) • RTL8832AU [2357:013f]
     TL_WDN6200       = "TL-WDN6200"      # https://github.com/aircrack-ng/rtl8812au/issues/1262

--- a/src/wifit3/chips/rtl8822bu/constants.py
+++ b/src/wifit3/chips/rtl8822bu/constants.py
@@ -94,7 +94,7 @@ USB_IDS_8822BU: tuple[tuple[int, int, str, str | None, str | None], ...] = (
     # TP-Link Archer T3U Plus v1: the user's lab device
     (0x2357, 0x0138, "RTL8822BU", None, TPLink.ARCHER_T3U_PLUS),
     (0x2357, 0x012D, "RTL8822BU", None, TPLink.ARCHER_T3U),
-    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+.
+    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+. https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
     (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3_PLUS),
     (0x2357, 0x012E, "RTL8822BU", None, TPLink.ARCHER_T3U_NANO),
     (0x2357, 0x0116, "RTL8822BU", None, None),  # (TP-Link) Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0116

--- a/src/wifit3/chips/rtl8822bu/constants.py
+++ b/src/wifit3/chips/rtl8822bu/constants.py
@@ -94,8 +94,8 @@ USB_IDS_8822BU: tuple[tuple[int, int, str, str | None, str | None], ...] = (
     # TP-Link Archer T3U Plus v1: the user's lab device
     (0x2357, 0x0138, "RTL8822BU", None, TPLink.ARCHER_T3U_PLUS),
     (0x2357, 0x012D, "RTL8822BU", None, TPLink.ARCHER_T3U),
-    # 2357:0115 could be one of: T4U Plus, T4U v3, T4U v3.2 https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
-    (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3),  # Chosen by dice roll.
+    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+.
+    (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3_PLUS),
     (0x2357, 0x012E, "RTL8822BU", None, TPLink.ARCHER_T3U_NANO),
     (0x2357, 0x0116, "RTL8822BU", None, None),  # (TP-Link) Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0116
     (0x2357, 0x0117, "RTL8822BU", None, None),  # (TP-Link) High Power Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0117

--- a/src/wifit3/chips/rtl8822bu_dkms/__init__.py
+++ b/src/wifit3/chips/rtl8822bu_dkms/__init__.py
@@ -8,7 +8,7 @@ from wifit3.chips.products import ASUS, Buffalo, CCandC, DLink, Edimax, Elecom, 
 _IDS = (
     (0x2357, 0x0138, "RTL8822BU", None, TPLink.ARCHER_T3U_PLUS),
     (0x2357, 0x012D, "RTL8822BU", None, TPLink.ARCHER_T3U),
-    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+.
+    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+. https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
     (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3_PLUS),
     (0x2357, 0x012E, "RTL8822BU", None, TPLink.ARCHER_T3U_NANO),
     (0x2357, 0x0116, "RTL8822BU", None, None),  # (TP-Link) Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0116

--- a/src/wifit3/chips/rtl8822bu_dkms/__init__.py
+++ b/src/wifit3/chips/rtl8822bu_dkms/__init__.py
@@ -8,8 +8,8 @@ from wifit3.chips.products import ASUS, Buffalo, CCandC, DLink, Edimax, Elecom, 
 _IDS = (
     (0x2357, 0x0138, "RTL8822BU", None, TPLink.ARCHER_T3U_PLUS),
     (0x2357, 0x012D, "RTL8822BU", None, TPLink.ARCHER_T3U),
-    # 2357:0115 could be one of: T4U Plus, T4U v3, T4U v3.2 https://wikidevi.wi-cat.ru/TP-LINK_Archer_T4U_v3
-    (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3),  # Chosen by dice roll.
+    # 2357:0115 is shared by Archer T4U v3/v3.2 and Archer T4U+.
+    (0x2357, 0x0115, "RTL8822BU", None, TPLink.ARCHER_T4U_V3_PLUS),
     (0x2357, 0x012E, "RTL8822BU", None, TPLink.ARCHER_T3U_NANO),
     (0x2357, 0x0116, "RTL8822BU", None, None),  # (TP-Link) Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0116
     (0x2357, 0x0117, "RTL8822BU", None, None),  # (TP-Link) High Power Wireless USB Adapter https://linux-hardware.org/?id=usb:2357-0117

--- a/src/wifit3/ui/screens/focus_v2/art.py
+++ b/src/wifit3/ui/screens/focus_v2/art.py
@@ -189,6 +189,7 @@ _ART_BY_PRODUCT: dict[str, str] = {
     TPLink.ARCHER_T3U_PLUS: "cards/card-archert3uplus.ans",
     TPLink.ARCHER_T4U_PLUS: "cards/card-archert4uplus.ans",
     TPLink.ARCHER_T4U_V3: "cards/card-archert4u.ans",
+    TPLink.ARCHER_T4U_V3_PLUS: "cards/card-archert4uplus.ans",
     TPLink.ARCHER_TX20U_PLUS: "cards/card-archertx20uplus.ans",
     TPLink.TL_WN722N_V1: "cards/card-tpwn722nv23.ans",       # AR9271 sibling; same physical card, same art
     TPLink.TL_WN722N_V2_V3: "cards/card-tpwn722nv23.ans",

--- a/tests/ui/test_card_art.py
+++ b/tests/ui/test_card_art.py
@@ -60,6 +60,10 @@ def test_art_path_for_wn722n_v1_shares_v23_art():
     assert art.art_path_for(_iface(product_name="TL-WN722N v1")) == "cards/card-tpwn722nv23.ans"
 
 
+def test_art_path_for_t4u_v3_plus_uses_plus_art():
+    assert art.art_path_for(_iface(product_name=TPLink.ARCHER_T4U_V3_PLUS)) == "cards/card-archert4uplus.ans"
+
+
 def test_art_path_for_ar9271_combined_label_defaults_to_alfa():
     # Pre-connect / MAC-less: the unsplit label resolves to the ALFA art, not the generic fallback.
     assert art.art_path_for(_iface(product_name=AMBIGUOUS_AR9271)) == "cards/card-awus036nha.ans"

--- a/tests/wlan/test_discovery.py
+++ b/tests/wlan/test_discovery.py
@@ -94,6 +94,19 @@ def test_both_8822_drivers_claim_0138():
     assert (0x2357, 0x0138) in {(e.vid, e.pid) for e in SUPPORTED_IDS}
 
 
+def test_rtl8822_t4u_v3_plus_uses_dkms_label(monkeypatch):
+    from wifit3.chips.products import TPLink
+    from wifit3.device import manager
+    monkeypatch.delenv("WIFIT3_RTL8822", raising=False)
+    manager.supported_ids.cache_clear()
+
+    cls, _key = manager.driver_for(0x2357, 0x0115)
+    entry, _key, _import_driver = manager.supported_ids()[(0x2357, 0x0115)]
+
+    assert cls.__name__ == "Rtl8822buDkmsDriver"
+    assert entry.product_name == TPLink.ARCHER_T4U_V3_PLUS
+
+
 def test_23570137_catalog_default_is_mt76x2u():
     # The catalog (no live device) keeps the mainline claim for the reused VID:PID.
     assert _driver_for(0x2357, 0x0137) == "MT76x2UDriver"


### PR DESCRIPTION
Adds documented support for T4U / T4U+ card.

There is a bug betwen distinguishing them, and my support is based on the T4U+ card. Ill assume T4U v3 is also supported as its the same card in software means, but still if somebody has that card if they can send its data to make distinguishing betwen them.