### PR TITLE
Rtl8821au efuse

### DIFF
--- a/docs/planning/BUGS.md
+++ b/docs/planning/BUGS.md
@@ -33,7 +33,7 @@ Most drivers were ported against the single device they were tested on, so EFUSE
 (antenna count, TX power tables) sit in the code as constants. A device whose EFUSE differs then
 gets wrong values with no error raised: little or no RX/TX, or wedging.
 
-Chipsets confirmed to honor EFUSE: RTL8822CU.
+Chipsets confirmed to honor EFUSE: RTL8822CU, RTL8821AU.
 
 Direction: per driver, list the EFUSE fields the vendor driver reads, compare against the wifit3
 driver, port what is missing. The vendor's per field parsers are uniformly named, so the field list

--- a/scripts/chips/rtl8821au_dkms/test_hw.py
+++ b/scripts/chips/rtl8821au_dkms/test_hw.py
@@ -230,7 +230,8 @@ def main() -> int:
             params = efuse.read_chip_params(t)
             print(f"  crystal_cap=0x{params.crystal_cap:02x} mac={params.mac_address or '<blank>'} "
                   f"bb_swing=0x{params.bb_swing_2g:03x}/0x{params.bb_swing_5g:03x} "
-                  f"ext_lna_2g={int(params.ext_lna_2g)} board_type=0x{params.board_type:02x}")
+                  f"ext_lna_2g={int(params.ext_lna_2g)} bt_coexist={int(params.bt_coexist)} "
+                  f"board_type=0x{params.board_type:02x}")
 
         fw = firmware.load_firmware_blob()
         print(f"[*] FW blob {len(fw)} bytes; running bring_up()...")

--- a/scripts/chips/rtl8821au_dkms/test_hw.py
+++ b/scripts/chips/rtl8821au_dkms/test_hw.py
@@ -145,10 +145,11 @@ async def _run_beacon(args) -> int:
           f"DIG watchdog: {'OFF' if args.no_dig else 'ON'}")
     start = time.monotonic()
     i = 0
+    transient_hop = len(channels) > 1
     try:
         while time.monotonic() - start < args.duration:
             cur = channels[i % len(channels)]
-            await driver.set_channel(cur)
+            await driver.set_channel(cur, scan=transient_hop)
             i += 1
             await interruptible_sleep(args.dwell)
             print(f"\r  {time.monotonic() - start:4.0f}s ch{cur:>3}  nAPs={len(tally.by_bssid)}  "

--- a/scripts/chips/rtl8821au_dkms/test_hw.py
+++ b/scripts/chips/rtl8821au_dkms/test_hw.py
@@ -39,7 +39,7 @@ import usb.util
 from _hwstop import interruptible_sleep
 
 from wifit3.chips.rtl8821au_dkms import SUPPORTED_IDS, constants as C
-from wifit3.chips.rtl8821au_dkms import bb, chan, firmware, mac, rf
+from wifit3.chips.rtl8821au_dkms import bb, chan, efuse, firmware, mac, rf, txpower
 from wifit3.chips.rtl8821au_dkms.driver import Rtl8821auDkmsDriver
 from wifit3.chips.rtl8821au_dkms.transport import RTL8821AUDkmsTransport
 
@@ -183,7 +183,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--phase", choices=("open", "fw", "mac", "phy", "chan", "beacon"),
                     default="chan")
-    ap.add_argument("--channel", type=int, default=1, help="fixed beacon-phase channel")
+    ap.add_argument("--channel", type=int, default=1, help="fixed chan/beacon-phase channel")
     ap.add_argument("--band", choices=("2g", "5g", "all"), default=None,
                     help="hop this band's channels instead of a fixed --channel")
     ap.add_argument("--dwell", type=float, default=2.0, help="per-channel dwell when hopping (s)")
@@ -224,6 +224,14 @@ def main() -> int:
             print("[PASS] control-transfer plumbing works.")
             return 0
 
+        params = None
+        if args.phase in ("phy", "chan"):
+            print("[*] reading EFUSE / chip parameters...")
+            params = efuse.read_chip_params(t)
+            print(f"  crystal_cap=0x{params.crystal_cap:02x} mac={params.mac_address or '<blank>'} "
+                  f"bb_swing=0x{params.bb_swing_2g:03x}/0x{params.bb_swing_5g:03x} "
+                  f"ext_lna_2g={int(params.ext_lna_2g)} board_type=0x{params.board_type:02x}")
+
         fw = firmware.load_firmware_blob()
         print(f"[*] FW blob {len(fw)} bytes; running bring_up()...")
         ready = firmware.bring_up(t, fw)
@@ -249,18 +257,48 @@ def main() -> int:
 
         if args.phase in ("phy", "chan"):
             print("[*] running PHY init (M3: BB PHY_REG/AGC + crystal_cap + RadioA)...")
-            bb.phy_bb_config(t, crystal_cap=0x27)   # TODO(efuse): read crystal_cap from EFUSE
-            rf.phy_rf_config(t)
+            jaguar_params = efuse.build_jaguar_params(params)
+            bb.phy_bb_config(t, crystal_cap=params.crystal_cap, params=jaguar_params)
+            rf.phy_rf_config(t, jaguar_params)
             xtal = t.read32(0x002C)
+            xcap = params.crystal_cap & 0x3F
+            expect = xcap | (xcap << 6)
             print(f"  REG 0x2C = 0x{xtal:08x}  (xtal field [23:12] = 0x{(xtal >> 12) & 0xFFF:03x}, "
-                  f"expect 0x9e7 for crystal_cap 0x27)")
+                  f"expect 0x{expect:03x} for crystal_cap 0x{params.crystal_cap:02x})")
+            if ((xtal >> 12) & 0xFFF) != expect:
+                return _fail("REG 0x2C crystal-cap field did not match EFUSE-derived value.")
             print("[PASS] PHY (BB + RF) init complete — no bus errors.")
 
         if args.phase == "chan":
-            print("[*] running channel tune (M4: 2.4 GHz band + ch1 + 20 MHz BW)...")
-            chan.set_chnl_bw(t, ch=1)
+            channel = args.channel
+            print(f"[*] running channel tune (M4/M7: ch{channel} + 20 MHz BW + TX power)...")
+            if channel <= 14:
+                chan.set_chnl_bw(t, ch=channel, bb_swing_2g=params.bb_swing_2g,
+                                 ext_lna_2g=params.ext_lna_2g)
+                txpower.set_tx_power(t, channel, params.tx_power)
+                group, cck_group = txpower._ch_group_2g(channel)
+                cck = txpower._pg_idx(params.tx_power, "cck", group, cck_group)
+                ofdm = txpower._pg_idx(params.tx_power, "ofdm", group, cck_group)
+                bw20 = txpower._pg_idx(params.tx_power, "bw20", group, cck_group)
+                checks = ((0x0C20, cck), (0x0C24, ofdm), (0x0C2C, bw20))
+            else:
+                chan.set_chnl_bw(t, ch=1, bb_swing_2g=params.bb_swing_2g,
+                                 ext_lna_2g=params.ext_lna_2g)
+                chan.set_channel_bw(t, channel, params.bb_swing_2g, params.bb_swing_5g,
+                                    params.ext_lna_2g)
+                txpower.set_tx_power_5g(t, channel, params.tx_power_5g)
+                group = txpower._ch_group_5g(channel)
+                ofdm = txpower._pg_idx(params.tx_power_5g, "ofdm", group, 0)
+                bw20 = txpower._pg_idx(params.tx_power_5g, "bw20", group, 0)
+                checks = ((0x0C24, ofdm), (0x0C2C, bw20))
             rf18 = rf._rf_serial_read(t, rf.RF_PATH_A, rf.RF_CHNLBW)
-            print(f"  RF[0x18] = 0x{rf18:05x}  (channel/BW reg — ch1 @ 20 MHz)")
+            print(f"  RF[0x18] = 0x{rf18:05x}  (channel/BW reg — ch{channel} @ 20 MHz)")
+            for reg, index in checks:
+                got = t.read32(reg)
+                expect = int.from_bytes(bytes([index]) * 4, "little")
+                print(f"  TXAGC[0x{reg:04x}] = 0x{got:08x}  expect 0x{expect:08x}")
+                if got != expect:
+                    return _fail("TXAGC register did not match EFUSE-derived power index.")
             print("[PASS] channel tune complete — no bus errors.")
     finally:
         try:

--- a/scripts/chips/rtl8821au_dkms/verify_efuse_pcap.py
+++ b/scripts/chips/rtl8821au_dkms/verify_efuse_pcap.py
@@ -43,7 +43,7 @@ def main() -> int:
     print(f"\nPASS: reproduced {t.i} probe ops byte-for-byte ({len(ops) - t.i} remain).")
     print(f"  crystal_cap = 0x{p.crystal_cap:02x}  (expect 0x27)")
     print(f"  mac_address = {p.mac_address or '<blank>'}")
-    print(f"  chip_version = 0x{p.chip_version:08x}  autoload_fail={p.autoload_fail}")
+    print(f"  chip_version = 0x{p.chip_version:08x}  autoload_fail={p.autoload_fail}  bt_coexist={p.bt_coexist}")
     tp = p.tx_power
     print(f"  2.4G CCK base  = {[hex(x) for x in tp.cck_base]}")
     print(f"  2.4G BW40 base = {[hex(x) for x in tp.bw40_base]}")

--- a/scripts/chips/rtl8821au_dkms/verify_pcap.py
+++ b/scripts/chips/rtl8821au_dkms/verify_pcap.py
@@ -107,7 +107,8 @@ def run(cap: str | None = None) -> int:
     print(f"FW blob: {len(fw)} bytes (body {len(fw) - 32})")
 
     p = _read_efuse_params(pcap, dev)
-    print(f"Efuse: crystal_cap=0x{p.crystal_cap:02x} (TX-power base cck[0]=0x{p.tx_power.cck_base[0]:02x} "
+    print(f"Efuse: crystal_cap=0x{p.crystal_cap:02x} bt_coexist={int(p.bt_coexist)} "
+          f"(TX-power base cck[0]=0x{p.tx_power.cck_base[0]:02x} "
           f"bw40[0]=0x{p.tx_power.bw40_base[0]:02x})")
 
     ops = rp.extract_ops(pcap, dev, WINDOW, start_addr=START_ADDR)

--- a/src/wifit3/chips/rtl8821au_dkms/RTL8821AU_DKMS.md
+++ b/src/wifit3/chips/rtl8821au_dkms/RTL8821AU_DKMS.md
@@ -86,9 +86,10 @@ proves it). The card reads `ext_lna_2g=0`, `board_type=0x00` (blank amplifier by
   runs it unconditionally to match. (This card's `rf_board_opt` BIT3=1, so an antdiv-enabled build
   WOULD gate it — a latent build-time dependency, not a runtime fuse gap.)
 
-**Residual not ported:** the BT `board_type` bit (`ODM_BOARD_BT`) — needs the
-`REG_MULTI_FUNC_CTRL` `BT_FUNC_EN` probe + the BTCoexist stack; a BT-combo module is out of scope
-(same call as the 8812/8814 siblings). `type_glna/gpa/alna/apa` stay 0 (`Hal_ReadPAType_8821A`
+**BT policy acknowledged, runtime coexist out of scope:** `efuse.read_chip_params` now probes
+`REG_MULTI_FUNC_CTRL` `BT_FUNC_EN`; a combo burn sets `bt_coexist` and ORs `ODM_BOARD_BT` into
+`board_type`, so the phy-cond policy sees the BT board bit. The BTCoexist runtime decision machine
+is still out of scope, same as RTL8822CU. `type_glna/gpa/alna/apa` stay 0 (`Hal_ReadPAType_8821A`
 never sets them — those are 8812-only), so a board_type-set card matches only the type-0 rows.
 
 ## Orientation
@@ -136,5 +137,5 @@ inputs). Both default to the reference values, so `verify_pcap` (2532 ops throug
 through M5) and `verify_channels` (36/36 hops) stay byte-exact through the generalized code. The
 other candidate branches (cut/package, phy_FixSpur, RF-read CCA, MP-chip AGC select, antenna-div
 DPDT) are card-independent on this build (documented with the vendor reason). Added `test_efuse.py`
-+ `test_chan.py` for the variant (non-reference) values. BT board_type bit + `type_*` remain
-unported residuals (BT-combo module out of scope).
++ `test_chan.py` for the variant (non-reference) values. BT board_type policy is now acknowledged;
+`type_*` remain 8812-only and stay 0.

--- a/src/wifit3/chips/rtl8821au_dkms/constants.py
+++ b/src/wifit3/chips/rtl8821au_dkms/constants.py
@@ -29,6 +29,7 @@ REG_SYS_FUNC_EN = 0x0002        # :40  (+1 = 0x0003, bit2 = 8051 core gate)
 REG_APS_FSMCO = 0x0004          # :41  (pwr-seq touches 0x04/0x05/0x06 byte-wise)
 REG_SYS_CLKR = 0x0008           # :42
 REG_RSV_CTRL = 0x001C           # :52  (8051 reset wrapper)
+REG_MULTI_FUNC_CTRL = 0x0068     # :78  (BT_FUNC_EN probe in EFUSE parse)
 REG_MCUFWDL = 0x0080            # :88  (FW download ctrl; +2 = page idx / 8051 rst hold)
 REG_SYS_CFG = 0x00F0            # :102 (no REG_SYS_CFG1/CFG2 in this tree)
 REG_CR = 0x0100                 # :117 (MAC DMA / WMAC / SCHEDULE / SEC enable)
@@ -123,6 +124,8 @@ EEPROM_MAC_ADDR_8821AU = 0x107
 PG_TXPWR_SADDR = 0x10          # hal_spec->pg_txpwr_saddr — TX-power PG block start
 EEPROM_TX_BBSWING_2G = 0xC6    # per-path TxScale index (2.4 GHz)
 EEPROM_TX_BBSWING_5G = 0xC7    # per-path TxScale index (5 GHz)
+EEPROM_RF_BOARD_OPTION_8821AU = 0xC1
+BIT_BT_FUNC_EN = BIT(18)
 # Amplifier-type PG bytes [SRC] hal_pg.h:144-146 (8812AU/8821AU shared offsets),
 # decoded by Hal_ReadPAType_8821A (rtl8812a_hal_init.c:1230). PAType 2G+5G packed at
 # 0xBC; per-band LNAType at 0xBD (2G) / 0xBF (5G).

--- a/src/wifit3/chips/rtl8821au_dkms/driver.py
+++ b/src/wifit3/chips/rtl8821au_dkms/driver.py
@@ -264,9 +264,7 @@ class Rtl8821auDkmsDriver(Driver):
         Serialized with set_channel / the DIG watchdog via ``_io_lock`` so the frame is never
         emitted mid-retune.
 
-        TX power is the BB-default (the per-rate EFUSE TX-power level is a separate deferred
-        milestone), adequate for a nearby target.
-        # TODO(txpower): per-rate EFUSE TX-power level for distant targets.
+        Per-rate EFUSE TX power is applied by connect() and every non-scan channel settle.
         """
         if len(frame_bytes) < 10:           # need addr1 (bytes [4:10]) to read BMC
             return False

--- a/src/wifit3/chips/rtl8821au_dkms/driver.py
+++ b/src/wifit3/chips/rtl8821au_dkms/driver.py
@@ -122,9 +122,9 @@ class Rtl8821auDkmsDriver(Driver):
                     params.bb_swing_2g, params.bb_swing_5g)
         # Detected board config — the runtime-fuse branches that make this driver card-
         # agnostic (ext-LNA RFE pinmux + phy_cond board_type). Reference reads 0/0x00.
-        logger.info("RTL8821AU config: ext_lna_2g=%d board_type=0x%02x%s",
-                    params.ext_lna_2g, params.board_type,
-                    "" if params.board_type == 0 else " (untested variant: external PA/LNA board)")
+        logger.info("RTL8821AU config: ext_lna_2g=%d bt_coexist=%d board_type=0x%02x%s",
+                    params.ext_lna_2g, params.bt_coexist, params.board_type,
+                    "" if params.board_type == 0 else " (untested variant: external PA/LNA/BT board)")
 
         if progress_cb:
             progress_cb(0.2, "Uploading firmware")

--- a/src/wifit3/chips/rtl8821au_dkms/efuse.py
+++ b/src/wifit3/chips/rtl8821au_dkms/efuse.py
@@ -29,9 +29,8 @@ from . import constants as C
 from .phy_cond import JaguarParams
 
 # ODM board_type bitfield [SRC] hal_dm.c:382-405 — the GLNA/GPA/ALNA/APA/BT bits the
-# JaguarSeries phy_cond walker matches against. On 8821a the board_type is assembled
-# from the four external-PA/LNA flags (Hal_ReadPAType_8821A); BT comes from a separate
-# REG_MULTI_FUNC_CTRL probe (non-BT board here, so BT stays 0 — see build_jaguar_params).
+# JaguarSeries phy_cond walker matches against.
+ODM_BOARD_BT = 1 << 2
 ODM_BOARD_EXT_PA_2G = 1 << 3      # ODM_BOARD_EXT_PA  (2G PA)
 ODM_BOARD_EXT_LNA_2G = 1 << 4     # ODM_BOARD_EXT_LNA (2G LNA)
 ODM_BOARD_EXT_PA_5G = 1 << 6
@@ -57,7 +56,8 @@ class ChipParams(NamedTuple):
     bb_swing_2g: int         # path-A TxScale (0x0C1C[31:21]) for 2.4 GHz
     bb_swing_5g: int         # path-A TxScale for 5 GHz
     ext_lna_2g: bool         # ExternalLNA_2G — gates the phy_SetRFEReg8821 2.4 GHz pinmux
-    board_type: int          # ODM ext-LNA/PA bitfield — the phy_cond walker's board input
+    bt_coexist: bool         # EEPROMBluetoothCoexist — ODM_BOARD_BT policy bit
+    board_type: int          # ODM ext-LNA/PA/BT bitfield — the phy_cond walker's board input
 
 
 def _efuse_one_byte_read(t, addr: int) -> int:
@@ -245,17 +245,20 @@ def _ext_amplifier_flags(m: bytes, autoload_fail: bool) -> tuple:
     return ext_pa_2g, ext_lna_2g, ext_pa_5g, ext_lna_5g
 
 
-def _parse_board_type(ext: tuple) -> int:
-    """[SRC] hal_dm.c:382-405 — assemble the ODM board_type from the external flags.
+def _parse_bt_coexist(m: bytes, multi_func_ctrl: int, autoload_fail: bool) -> bool:
+    """[SRC] Hal_EfuseParseBTCoexistInfo — EEPROMBluetoothCoexist policy bit."""
+    if autoload_fail:
+        return False
+    value = m[C.EEPROM_RF_BOARD_OPTION_8821AU]
+    if value == 0xFF:
+        return False
+    return ((value & 0xE0) >> 5) == 0x01 and bool(multi_func_ctrl & C.BIT_BT_FUNC_EN)
 
-    Each set external flag lights its ODM_BOARD bit (GPA bit3 / GLNA bit4 / APA bit6 / ALNA
-    bit7). BT (bit2) needs the REG_MULTI_FUNC_CTRL BT_FUNC_EN probe (rtl8812a_hal_init.c:831);
-    the AWUS036ACS is a non-BT board, so BT stays 0 and the BT decode is not ported. The
-    per-path type_* sub-codes (TypeGLNA/TypeGPA/...) are 8812-only — Hal_ReadPAType_8821A does
-    not set them — so they stay 0 for the 8821 walker.
-    """
+
+def _parse_board_type(ext: tuple, bt_coexist: bool = False) -> int:
+    """[SRC] hal_dm.c:382-405 — assemble the ODM board_type from EFUSE policy flags."""
     ext_pa_2g, ext_lna_2g, ext_pa_5g, ext_lna_5g = ext
-    board_type = 0
+    board_type = ODM_BOARD_BT if bt_coexist else 0
     if ext_lna_2g:
         board_type |= ODM_BOARD_EXT_LNA_2G
     if ext_lna_5g:
@@ -282,7 +285,7 @@ def read_chip_params(t) -> ChipParams:
     EFUSE access-on + power-switch reads, the byte loop, access-off.
     """
     chip_version = t.read32(C.REG_SYS_CFG)         # ReadChipVersion (0xF0)
-    t.read32(0x0068)                               # version-id companion read
+    multi_func_ctrl = t.read32(C.REG_MULTI_FUNC_CTRL)  # Hal_EfuseParseBTCoexistInfo input
     ee = t.read8(C.REG_9346CR)
     autoload_fail = not (ee & (1 << 5))            # bit5 = EEPROM present
 
@@ -294,6 +297,7 @@ def read_chip_params(t) -> ChipParams:
     t.write8(C.REG_EFUSE_ACCESS, C.EFUSE_ACCESS_OFF)
 
     ext = _ext_amplifier_flags(m, autoload_fail)   # Hal_ReadPAType_8821A
+    bt_coexist = _parse_bt_coexist(m, multi_func_ctrl, autoload_fail)
     return ChipParams(
         crystal_cap=_parse_crystal_cap(m),
         mac_address=_parse_mac_address(m),
@@ -304,7 +308,8 @@ def read_chip_params(t) -> ChipParams:
         bb_swing_2g=_parse_bb_swing(m, C.EEPROM_TX_BBSWING_2G),
         bb_swing_5g=_parse_bb_swing(m, C.EEPROM_TX_BBSWING_5G),
         ext_lna_2g=ext[1],
-        board_type=_parse_board_type(ext),
+        bt_coexist=bt_coexist,
+        board_type=_parse_board_type(ext, bt_coexist),
     )
 
 

--- a/tests/chips/rtl8821au_dkms/test_efuse.py
+++ b/tests/chips/rtl8821au_dkms/test_efuse.py
@@ -50,9 +50,18 @@ def test_ext_flags_full_decode():
     assert flags == (True, True, True, True)   # pa&0x10, lna2g&0x08, pa&0x01, lna5g&0x08
 
 
+def test_bt_coexist_policy_bit():
+    m = bytearray(_map())
+    m[efuse.C.EEPROM_RF_BOARD_OPTION_8821AU] = 0x20
+
+    assert efuse._parse_bt_coexist(bytes(m), efuse.C.BIT_BT_FUNC_EN, autoload_fail=False) is True
+    assert efuse._parse_bt_coexist(bytes(m), 0, autoload_fail=False) is False
+    assert efuse._parse_bt_coexist(bytes(m), efuse.C.BIT_BT_FUNC_EN, autoload_fail=True) is False
+
+
 def test_board_type_bits():
-    bt = efuse._parse_board_type((True, True, True, True))
-    assert bt == (efuse.ODM_BOARD_EXT_PA_2G | efuse.ODM_BOARD_EXT_LNA_2G
+    bt = efuse._parse_board_type((True, True, True, True), bt_coexist=True)
+    assert bt == (efuse.ODM_BOARD_BT | efuse.ODM_BOARD_EXT_PA_2G | efuse.ODM_BOARD_EXT_LNA_2G
                   | efuse.ODM_BOARD_EXT_PA_5G | efuse.ODM_BOARD_EXT_LNA_5G)
     assert efuse._parse_board_type((False, True, False, False)) == efuse.ODM_BOARD_EXT_LNA_2G
 


### PR DESCRIPTION
the dkms driver for rtl8821au honors efuse to the same level as 8822cu, bt coexist is ackgnowledged but not implemented / enabled in the card. (honestly the driver was pretty good, just smoke test didnt use efuse values and bt coexist ackgnowledge wasnt implemented)